### PR TITLE
🪲 [Fix]: Fix `Set-Store` to take secret as both `String` or `SecureString`

### DIFF
--- a/src/functions/public/Store/Set-Store.ps1
+++ b/src/functions/public/Store/Set-Store.ps1
@@ -30,17 +30,27 @@
 
         # The secret of the store.
         [Parameter()]
-        [string] $Secret = 'null',
+        [object] $Secret = 'null',
 
         # The variables of the store.
         [Parameter()]
         [hashtable] $Variables
     )
+
     $param = @{
-        Name   = $Name
-        Secret = $Secret
-        Vault  = $script:Config.SecretVaultName
+        Name  = $Name
+        Vault = $script:Config.SecretVaultName
     }
+
+    #Map secret based on type, to Secret or SecureStringSecret
+    if ($Secret -is [System.Security.SecureString]) {
+        $param['SecureStringSecret'] = $Secret
+    } elseif ($Secret -is [string]) {
+        $param['Secret'] = $Secret
+    } else {
+        throw 'Invalid secret type'
+    }
+
     if ($Variables) {
         $param.Metadata = $Variables
     }

--- a/tests/Store.Tests.ps1
+++ b/tests/Store.Tests.ps1
@@ -18,7 +18,14 @@ Describe 'Store' {
         It "Set-Store -Name 'Test' -Variables @{ 'Test' = 'Test' }" {
             { Set-Store -Name 'Test' -Variables @{ 'Test' = 'Test' } } | Should -Not -Throw
         }
-
+        # Write two tests setting a secret, one as a string, one as a SecureString
+        It "Set-Store -Name 'Test' -Secret 'Test' - Secret as String" {
+            { Set-Store -Name 'Test' -Secret 'Test' } | Should -Not -Throw
+        }
+        It "Set-Store -Name 'Test' -Secret 'Test' - Secret as SecureString" {
+            $secret = 'Test' | ConvertTo-SecureString -AsPlainText -Force
+            { Set-Store -Name 'Test' -Secret $secret } | Should -Not -Throw
+        }
     }
     Context 'Get-Store' {
         It 'Should be available' {


### PR DESCRIPTION
## Description

- Fix `Set-Store` to take secret as both `String` or `SecureString`

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
