### PR TITLE
🪲 [Fix]: Fix an issue with `Get-Context` -with blank `Name`

### DIFF
--- a/src/functions/public/Context/Get-Context.ps1
+++ b/src/functions/public/Context/Get-Context.ps1
@@ -1,6 +1,6 @@
 #Requires -Modules @{ ModuleName = 'Microsoft.PowerShell.SecretManagement'; RequiredVersion = '1.1.2' }
 
-function Get-Context {
+filter Get-Context {
     <#
         .SYNOPSIS
         Retrieves a context from the context vault.
@@ -40,28 +40,23 @@ function Get-Context {
         )]
         [SupportsWildcards()]
         [Alias('Context', 'ContextName')]
-        [string] $Name,
+        [string] $Name = '*',
 
         # Switch to retrieve all the contexts secrets as plain text.
         [Parameter()]
         [switch] $AsPlainText
     )
 
-    begin {
-        $filter = if ([string]::IsNullOrEmpty($PSBoundParameters.Name)) { '*' } else { $PSBoundParameters.Name }
-        $Name = $($script:Config.Name) + $filter
-    }
+    $Name = $($script:Config.Name) + $Name
 
-    process {
-        $contextVault = Get-ContextVault
+    $contextVault = Get-ContextVault
 
-        Write-Verbose "Retrieving contexts from vault [$($contextVault.Name)] using pattern [$Name]"
-        $contexts = Get-SecretInfo -Vault $contextVault.Name | Where-Object { $_.Name -like "$Name" }
+    Write-Verbose "Retrieving contexts from vault [$($contextVault.Name)] using pattern [$Name]"
+    $contexts = Get-SecretInfo -Vault $contextVault.Name | Where-Object { $_.Name -like "$Name" }
 
-        Write-Verbose "Found [$($contexts.Count)] contexts in context vault [$($contextVault.Name)]"
-        foreach ($context in $contexts) {
-            Get-Secret -Name $context.Name -Vault $contextVault.Name -AsPlainText:$AsPlainText
-        }
+    Write-Verbose "Found [$($contexts.Count)] contexts in context vault [$($contextVault.Name)]"
+    foreach ($context in $contexts) {
+        Get-Secret -Name $context.Name -Vault $contextVault.Name -AsPlainText:$AsPlainText
     }
 }
 

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -16,6 +16,15 @@ Describe 'Context' {
         It "Get-Context -Name '*' - Should return all contexts" {
             { Get-Context -Name '*' } | Should -Not -Throw
         }
+
+        It "Get-Context -Name '' - Should return no contexts" {
+            { Get-Context -Name '' } | Should -Not -Throw
+            Get-Context -Name '' | Should -BeNullOrEmpty
+        }
+        It 'Get-Context -Name $null - Should return no contexts' {
+            { Get-Context -Name $null } | Should -Not -Throw
+            Get-Context -Name $null | Should -BeNullOrEmpty
+        }
     }
 
     Context 'Function: Set-Context' {


### PR DESCRIPTION
## Description

- Fix an issue with `Get-Context`,  where it would return all context if `-Name` is `$null` or `''` (empty string), when it should be returning no contexts.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
