### PR TITLE
🩹 [Patch]: Update `Remove-Context` to retrieve context names from `Get-SecretInfo`

### DIFF
--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -50,7 +50,8 @@ filter Remove-Context {
     )
 
     $contextVault = Get-ContextVault
-    $contextNames = Get-Context -Name $Name -AsPlainText | Select-Object -ExpandProperty Name
+    $Name = "$($script:Config.Name)$Name"
+    $contextNames = Get-SecretInfo -Name $Name -AsPlainText | Select-Object -ExpandProperty Name
 
     Write-Verbose "Removing [$($contextNames.count)] contexts from vault [$($contextVault.Name)]"
     foreach ($contextName in $contextNames) {

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -54,7 +54,7 @@ filter Remove-Context {
     $contextNames = Get-SecretInfo -Vault $script:Config.Context.VaultName | Where-Object { $_.Name -like "$Name" } |
         Select-Object -ExpandProperty Name
 
-    Write-Verbose "Removing [$($contextNames.count)] contexts from vault [$($contextVault.Name)]"
+    Write-Verbose "Removing [$($contextNames.count)] contexts from vault [$($contextVault.Name)] using filter [$Name]"
     foreach ($contextName in $contextNames) {
         Write-Verbose "Removing context [$contextName]"
         if ($PSCmdlet.ShouldProcess('Remove-Secret', $contextName)) {

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -51,7 +51,8 @@ filter Remove-Context {
 
     $contextVault = Get-ContextVault
     $Name = "$($script:Config.Name)$Name"
-    $contextNames = Get-SecretInfo -Name $Name -AsPlainText | Select-Object -ExpandProperty Name
+    $contextNames = Get-SecretInfo -Vault $script:Config.Context.VaultName | Where-Object { $_.Name -like "$Name" } |
+        Select-Object -ExpandProperty Name
 
     Write-Verbose "Removing [$($contextNames.count)] contexts from vault [$($contextVault.Name)]"
     foreach ($contextName in $contextNames) {

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -57,7 +57,6 @@ filter Remove-Context {
     Write-Verbose "Removing [$($contextNames.count)] contexts from vault [$($contextVault.Name)]"
     foreach ($contextName in $contextNames) {
         Write-Verbose "Removing context [$contextName]"
-        $contextName = $($script:Config.Name) + $contextName
         if ($PSCmdlet.ShouldProcess('Remove-Secret', $contextName)) {
             Write-Verbose "Removing secret [$contextName]"
             Remove-Secret -Name $contextName -Vault $contextVault.Name

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -46,8 +46,12 @@ filter Remove-Context {
         )]
         [SupportsWildcards()]
         [Alias('Context', 'ContextName')]
-        [string] $Name = '*'
+        [object] $Name = '*'
     )
+
+    if ($Name -is [hashtable]) {
+        $Name = $Name.Name
+    }
 
     $contextVault = Get-ContextVault
     $Name = "$($script:Config.Name)$Name"

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -40,18 +40,11 @@ filter Remove-Context {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         # The name of the context to remove from the vault. Supports wildcard patterns.
-        [Parameter(
-            ValueFromPipeline,
-            ValueFromPipelineByPropertyName
-        )]
+        [Parameter()]
         [SupportsWildcards()]
         [Alias('Context', 'ContextName')]
         [object] $Name = '*'
     )
-
-    if ($Name -is [hashtable]) {
-        $Name = $Name.Name
-    }
 
     $contextVault = Get-ContextVault
     $Name = "$($script:Config.Name)$Name"

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -125,35 +125,6 @@ Describe 'Context' {
         It 'Can delete using a wildcard' {
             { Remove-Context -Name 'Test*' } | Should -Not -Throw
         }
-        It 'Can delete contexts using pipeline' {
-            $Context = @{
-                Name         = 'Test6'
-                AccessToken  = 'MySecret' | ConvertTo-SecureString -AsPlainText -Force
-                RefreshToken = 'MyRefreshedSecret' | ConvertTo-SecureString -AsPlainText -Force
-            }
-
-            { Set-Context -Context $Context } | Should -Not -Throw
-
-            $Context = @{
-                Name         = 'Test7'
-                AccessToken  = 'MySecret' | ConvertTo-SecureString -AsPlainText -Force
-                RefreshToken = 'MyRefreshedSecret' | ConvertTo-SecureString -AsPlainText -Force
-            }
-
-            { Set-Context -Context $Context } | Should -Not -Throw
-
-            $Context = @{
-                Name         = 'Test8'
-                AccessToken  = 'MySecret' | ConvertTo-SecureString -AsPlainText -Force
-                RefreshToken = 'MyRefreshedSecret' | ConvertTo-SecureString -AsPlainText -Force
-            }
-
-            { Set-Context -Context $Context } | Should -Not -Throw
-
-            Get-Context -Name 'Test*' | Should -Not -BeNullOrEmpty
-            { Get-Context -Name 'Test*' | Remove-Context } | Should -Not -Throw
-            Get-Context -Name 'Test*' | Should -BeNullOrEmpty
-        }
     }
 
     Context 'Set-ContextSetting' {

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -57,7 +57,7 @@ Describe 'Context' {
         }
 
         It 'Get-Context - Should return all contexts' {
-            { Get-Context } | Should -Not -Throw
+            (Get-Context).Count | Should -Be 2
         }
 
         It "Get-Context -Name '*' - Should return all contexts" {
@@ -152,6 +152,7 @@ Describe 'Context' {
 
             Get-Context -Name 'Test*' | Should -Not -BeNullOrEmpty
             { Get-Context -Name 'Test*' | Remove-Context } | Should -Not -Throw
+            Get-Context -Name 'Test*' | Should -BeNullOrEmpty
         }
     }
 

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -61,7 +61,7 @@ Describe 'Context' {
         }
 
         It "Get-Context -Name '*' - Should return all contexts" {
-            { Get-Context -Name '*' } | Should -Not -Throw
+            (Get-Context -Name '*').Count | Should -Be 2
         }
 
         It "Get-Context -Name '' - Should return no contexts" {


### PR DESCRIPTION
## Description

- Update `Remove-Context` to retrieve context names from `Get-SecretInfo`.
- Remove option to pass pipeline input to `Remove-Context`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
