### PR TITLE
🪲 [Fix]: Update verbose output in `Set-ContextSetting` to use context ID

### DIFF
--- a/src/functions/public/ContextSetting/Set-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Set-ContextSetting.ps1
@@ -47,7 +47,7 @@ function Set-ContextSetting {
     }
 
     if ($PSCmdlet.ShouldProcess($Name, "Set value [$Value]")) {
-        Write-Verbose "Setting [$Name] to [$Value] in [$($context.Name)]"
+        Write-Verbose "Setting [$Name] to [$Value] in [$ID]"
         if ($context.PSObject.Properties[$Name]) {
             $context.$Name = $Value
         } else {


### PR DESCRIPTION
## Description

- Update verbose output in `Set-ContextSetting` to use context ID

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
