### PR TITLE
🚀 [Feature]: Improve error handling + fix Get-Context + Add Rename-Context

### DIFF
--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -29,3 +29,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_YAML_PRETTIER: false
+          VALIDATE_JSCPD: false

--- a/README.md
+++ b/README.md
@@ -15,13 +15,17 @@ in the `SecretStore`. The `Context` is stored in the `SecretVault` as a secret w
 The context is stored as compressed JSON and could look something like the examples below. These are the same data but one shows the JSON structure
 that is stored in the `SecretStore` and the other shows the same data as a `PSCustomObject` that could be used in a PowerShell script.
 
+The ID of the context is the name of the secret that it is stored as in the `SecretStore`. The ID is also stored with the context as a property in the
+context data structure. This is to make it easier to find the context when you only have the context object.
+
 <details>
-<summary>PSCustomObject</summary>
+<summary>Input to Set-Context - As a PSCustomObject</summary>
 
 Typical the first input to a context (altho it can also be a hashtable or any other object type that converts with JSON)
+This object should NOT have a property on root of the object called `ID` as this is added by the module.
 
 ```pwsh
-[PSCustomObject]@{
+Set-Context -ID 'john_doe' -Context ([PSCustomObject]@{
     Username          = 'john_doe'
     AuthToken         = 'ghp_12345ABCDE67890FGHIJ' | ConvertTo-SecureString -AsPlainText -Force #gitleaks:allow
     LoginTime         = Get-Date
@@ -83,17 +87,19 @@ Typical the first input to a context (altho it can also be a hashtable or any ot
             Version = '118.0.1'
         }
     }
-}
+})
 ```
 </details>
 
 <details>
-<summary>JSON</summary>
+<summary>The stored data in a secret - As a processed JSON</summary>
 
-This is same as what is stored, except that this is an uncomressed version for readability.
+This is how the objecet above is stored, except that this is an uncomressed version for readability.
+Here you see that the `ID` property is added.
 
 ```json
 {
+    "ID": "Context:john_doe",
     "Username": "john_doe",
     "AuthToken": "[SECURESTRING]ghp_12345ABCDE67890FGHIJ",
     "LoginTime": "2024-11-21T21:16:56.2518249+01:00",
@@ -176,6 +182,30 @@ This is same as what is stored, except that this is an uncomressed version for r
 }
 ```
 </details>
+
+<details>
+<summary>Output from Get-Context - As a PSCustomObject</summary>
+
+This is how the object is returned from the `Get-Context` function.
+Notice that the `ID` property has been added to the object.
+
+```pwsh
+Get-Context -ID 'john_doe'
+
+ID                : Context:john_doe
+UserPreferences   : @{DefaultBranch=main; Notifications=; Theme=dark; CodeReview=System.Object[]}
+LastLoginAttempts : {@{Success=True; IP=System.Security.SecureString; Timestamp=11/24/2024 2:09:12 PM}, @{Success=False; IP=System.Security.SecureString; Timestamp=11/23/2024 3:09:12 PM}}
+IsTwoFactorAuth   : True
+AuthToken         : System.Security.SecureString
+TwoFactorMethods  : {TOTP, SMS}
+LoginTime         : 11/24/2024 3:09:12 PM
+ApiRateLimits     : @{Limit=5000; Remaining=4985; ResetTime=11/24/2024 3:39:12 PM}
+Repositories      : {@{CreatedDate=5/24/2024 3:09:12 PM; Stars=42; Name=Repo1; IsPrivate=True; Languages=System.Object[]}, @{CreatedDate=11/24/2023 3:09:12 PM; Stars=130; Name=Repo2; IsPrivate=False;
+                    Languages=System.Object[]}}
+SessionMetaData   : @{BrowserInfo=; Device=Windows-PC; Location=; SessionID=sess_abc123}
+Username          : john_doe
+AccessScopes      : {repo, user, gist, admin:org}
+```
 
 ## Prerequisites
 

--- a/src/functions/private/Get-ContextVault.ps1
+++ b/src/functions/private/Get-ContextVault.ps1
@@ -19,21 +19,32 @@ function Get-ContextVault {
     [CmdletBinding()]
     param()
 
-    try {
-        if (-not $script:Config.VaultName) {
-            throw 'Context vault name not set'
-        }
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Verbose "[$commandName] - Start"
+    }
 
-        Write-Verbose "Connecting to context vault [$($script:Config.VaultName)]"
-        $secretVault = Get-SecretVault | Where-Object { $_.Name -eq $script:Config.VaultName }
-        if (-not $secretVault) {
+    process {
+        try {
+            if (-not $script:Config.VaultName) {
+                throw 'Context vault name not set'
+            }
+
+            Write-Verbose "Connecting to context vault [$($script:Config.VaultName)]"
+            $secretVault = Get-SecretVault | Where-Object { $_.Name -eq $script:Config.VaultName }
+            if (-not $secretVault) {
+                Write-Error $_
+                throw "Context vault [$($script:Config.VaultName)] not found"
+            }
+
+            return $secretVault
+        } catch {
             Write-Error $_
-            throw "Context vault [$($script:Config.VaultName)] not found"
+            throw 'Failed to get context vault'
         }
+    }
 
-        return $secretVault
-    } catch {
-        Write-Error $_
-        throw 'Failed to get context vault'
+    end {
+        Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/private/Get-ContextVault.ps1
+++ b/src/functions/private/Get-ContextVault.ps1
@@ -33,6 +33,7 @@ function Get-ContextVault {
 
         return $secretVault
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to get context vault'
     }
 }

--- a/src/functions/private/Get-ContextVault.ps1
+++ b/src/functions/private/Get-ContextVault.ps1
@@ -21,7 +21,7 @@ function Get-ContextVault {
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
     }
 
     process {
@@ -45,6 +45,6 @@ function Get-ContextVault {
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }

--- a/src/functions/private/Initialize-ContextVault.ps1
+++ b/src/functions/private/Initialize-ContextVault.ps1
@@ -34,7 +34,7 @@ function Initialize-ContextVault {
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
     }
 
     process {
@@ -76,6 +76,6 @@ function Initialize-ContextVault {
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }

--- a/src/functions/private/Initialize-ContextVault.ps1
+++ b/src/functions/private/Initialize-ContextVault.ps1
@@ -63,6 +63,7 @@ function Initialize-ContextVault {
 
         Get-SecretVault | Where-Object { $_.ModuleName -eq $Type }
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to initialize context vault'
     }
 }

--- a/src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1
+++ b/src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1
@@ -33,7 +33,7 @@
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
     }
 
     process {
@@ -76,6 +76,6 @@
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }

--- a/src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1
+++ b/src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1
@@ -37,8 +37,8 @@
         foreach ($key in $Hashtable.Keys) {
             $value = $Hashtable[$key]
             Write-Debug "Processing [$key]"
-            Write-Debug "Value type: $($value.GetType().FullName)"
             Write-Debug "Value: $value"
+            Write-Debug "Type:  $($value.GetType().Name)"
             if ($value -is [string] -and $value -like '`[SECURESTRING`]*') {
                 Write-Debug "Converting [$key] as [SecureString]"
                 $secureValue = $value -replace '^\[SECURESTRING\]', ''
@@ -64,6 +64,7 @@
         }
         return $result
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to convert hashtable to object'
     }
 }

--- a/src/functions/private/JsonToObject/ConvertFrom-ContextJson.ps1
+++ b/src/functions/private/JsonToObject/ConvertFrom-ContextJson.ps1
@@ -31,6 +31,7 @@
         $hashtableObject = $JsonString | ConvertFrom-Json -Depth 100 -AsHashtable
         return Convert-ContextHashtableToObjectRecursive $hashtableObject
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to convert JSON to object'
     }
 }

--- a/src/functions/private/JsonToObject/ConvertFrom-ContextJson.ps1
+++ b/src/functions/private/JsonToObject/ConvertFrom-ContextJson.ps1
@@ -27,11 +27,23 @@
         [Parameter(Mandatory)]
         [string] $JsonString
     )
-    try {
-        $hashtableObject = $JsonString | ConvertFrom-Json -Depth 100 -AsHashtable
-        return Convert-ContextHashtableToObjectRecursive $hashtableObject
-    } catch {
-        Write-Error $_
-        throw 'Failed to convert JSON to object'
+
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Verbose "[$commandName] - Start"
+    }
+
+    process {
+        try {
+            $hashtableObject = $JsonString | ConvertFrom-Json -Depth 100 -AsHashtable
+            return Convert-ContextHashtableToObjectRecursive $hashtableObject
+        } catch {
+            Write-Error $_
+            throw 'Failed to convert JSON to object'
+        }
+    }
+
+    end {
+        Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/private/JsonToObject/ConvertFrom-ContextJson.ps1
+++ b/src/functions/private/JsonToObject/ConvertFrom-ContextJson.ps1
@@ -30,7 +30,7 @@
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
     }
 
     process {
@@ -44,6 +44,6 @@
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }

--- a/src/functions/private/ObjectToJSON/Convert-ContextObjectToHashtableRecursive.ps1
+++ b/src/functions/private/ObjectToJSON/Convert-ContextObjectToHashtableRecursive.ps1
@@ -28,51 +28,62 @@
         [object] $Object
     )
 
-    try {
-        $result = @{}
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Verbose "[$commandName] - Start"
+    }
 
-        if ($Object -is [hashtable]) {
-            Write-Debug 'Converting [hashtable] to [PSCustomObject]'
-            $Object = [PSCustomObject]$Object
-        } elseif ($Object -is [string] -or $Object -is [int] -or $Object -is [bool]) {
-            Write-Debug 'returning as string'
-            return $Object
-        }
+    process {
+        try {
+            $result = @{}
 
-        foreach ($property in $Object.PSObject.Properties) {
-            $name = $property.Name
-            $value = $property.Value
-            Write-Debug "Processing [$name]"
-            Write-Debug "Value: $value"
-            Write-Debug "Type:  $($value.GetType().Name)"
-            if ($value -is [datetime]) {
-                Write-Debug '- as DateTime'
-                $result[$property.Name] = $value.ToString('o')
-            } elseif ($value -is [string] -or $Object -is [int] -or $Object -is [bool]) {
-                Write-Debug '- as string, int, bool'
-                $result[$property.Name] = $value
-            } elseif ($value -is [System.Security.SecureString]) {
-                Write-Debug '- as SecureString'
-                $value = $value | ConvertFrom-SecureString -AsPlainText
-                $result[$property.Name] = "[SECURESTRING]$value"
-            } elseif ($value -is [psobject] -or $value -is [PSCustomObject] -or $value -is [hashtable]) {
-                Write-Debug '- as PSObject, PSCustomObject or hashtable'
-                $result[$property.Name] = Convert-ContextObjectToHashtableRecursive $value
-            } elseif ($value -is [System.Collections.IEnumerable]) {
-                Write-Debug '- as IEnumerable, including arrays and hashtables'
-                $result[$property.Name] = @(
-                    $value | ForEach-Object {
-                        Convert-ContextObjectToHashtableRecursive $_
-                    }
-                )
-            } else {
-                Write-Debug '- as regular value'
-                $result[$property.Name] = $value
+            if ($Object -is [hashtable]) {
+                Write-Debug 'Converting [hashtable] to [PSCustomObject]'
+                $Object = [PSCustomObject]$Object
+            } elseif ($Object -is [string] -or $Object -is [int] -or $Object -is [bool]) {
+                Write-Debug 'returning as string'
+                return $Object
             }
+
+            foreach ($property in $Object.PSObject.Properties) {
+                $name = $property.Name
+                $value = $property.Value
+                Write-Debug "Processing [$name]"
+                Write-Debug "Value: $value"
+                Write-Debug "Type:  $($value.GetType().Name)"
+                if ($value -is [datetime]) {
+                    Write-Debug '- as DateTime'
+                    $result[$property.Name] = $value.ToString('o')
+                } elseif ($value -is [string] -or $Object -is [int] -or $Object -is [bool]) {
+                    Write-Debug '- as string, int, bool'
+                    $result[$property.Name] = $value
+                } elseif ($value -is [System.Security.SecureString]) {
+                    Write-Debug '- as SecureString'
+                    $value = $value | ConvertFrom-SecureString -AsPlainText
+                    $result[$property.Name] = "[SECURESTRING]$value"
+                } elseif ($value -is [psobject] -or $value -is [PSCustomObject] -or $value -is [hashtable]) {
+                    Write-Debug '- as PSObject, PSCustomObject or hashtable'
+                    $result[$property.Name] = Convert-ContextObjectToHashtableRecursive $value
+                } elseif ($value -is [System.Collections.IEnumerable]) {
+                    Write-Debug '- as IEnumerable, including arrays and hashtables'
+                    $result[$property.Name] = @(
+                        $value | ForEach-Object {
+                            Convert-ContextObjectToHashtableRecursive $_
+                        }
+                    )
+                } else {
+                    Write-Debug '- as regular value'
+                    $result[$property.Name] = $value
+                }
+            }
+            return $result
+        } catch {
+            Write-Error $_
+            throw 'Failed to convert context object to hashtable'
         }
-        return $result
-    } catch {
-        Write-Error $_
-        throw 'Failed to convert context object to hashtable'
+    }
+
+    end {
+        Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/private/ObjectToJSON/Convert-ContextObjectToHashtableRecursive.ps1
+++ b/src/functions/private/ObjectToJSON/Convert-ContextObjectToHashtableRecursive.ps1
@@ -30,7 +30,7 @@
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
     }
 
     process {
@@ -84,6 +84,6 @@
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }

--- a/src/functions/private/ObjectToJSON/Convert-ContextObjectToHashtableRecursive.ps1
+++ b/src/functions/private/ObjectToJSON/Convert-ContextObjectToHashtableRecursive.ps1
@@ -40,9 +40,11 @@
         }
 
         foreach ($property in $Object.PSObject.Properties) {
+            $name = $property.Name
             $value = $property.Value
-            Write-Debug "Processing [$($property.Name)]"
-            Write-Debug "Value type: $($value.GetType().FullName)"
+            Write-Debug "Processing [$name]"
+            Write-Debug "Value: $value"
+            Write-Debug "Type:  $($value.GetType().Name)"
             if ($value -is [datetime]) {
                 Write-Debug '- as DateTime'
                 $result[$property.Name] = $value.ToString('o')
@@ -70,6 +72,7 @@
         }
         return $result
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to convert context object to hashtable'
     }
 }

--- a/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
+++ b/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
@@ -33,7 +33,7 @@
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
     }
 
     process {
@@ -47,6 +47,6 @@
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }

--- a/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
+++ b/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
@@ -41,10 +41,6 @@
     }
 
     process {
-        if ($Context.PSObject.Properties.Name -Contains 'ID') {
-            throw 'ID is a reserved property and will contain the context ID. Please use a different property name.'
-        }
-
         try {
             $processedObject = Convert-ContextObjectToHashtableRecursive $Context
             $processedObject['ID'] = $ID

--- a/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
+++ b/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
@@ -31,11 +31,22 @@
         [object] $Context
     )
 
-    try {
-        $processedObject = Convert-ContextObjectToHashtableRecursive $Context
-        return ($processedObject | ConvertTo-Json -Depth 100 -Compress)
-    } catch {
-        Write-Error $_
-        throw 'Failed to convert object to JSON'
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Verbose "[$commandName] - Start"
+    }
+
+    process {
+        try {
+            $processedObject = Convert-ContextObjectToHashtableRecursive $Context
+            return ($processedObject | ConvertTo-Json -Depth 100 -Compress)
+        } catch {
+            Write-Error $_
+            throw 'Failed to convert object to JSON'
+        }
+    }
+
+    end {
+        Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
+++ b/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
@@ -35,6 +35,7 @@
         $processedObject = Convert-ContextObjectToHashtableRecursive $Context
         return ($processedObject | ConvertTo-Json -Depth 100 -Compress)
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to convert object to JSON'
     }
 }

--- a/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
+++ b/src/functions/private/ObjectToJSON/ConvertTo-ContextJson.ps1
@@ -28,7 +28,11 @@
     param (
         # The object to convert to a Context JSON string.
         [Parameter(Mandatory)]
-        [object] $Context
+        [object] $Context,
+
+        # The ID of the context.
+        [Parameter(Mandatory)]
+        [string] $ID
     )
 
     begin {
@@ -37,8 +41,13 @@
     }
 
     process {
+        if ($Context.PSObject.Properties.Name -Contains 'ID') {
+            throw 'ID is a reserved property and will contain the context ID. Please use a different property name.'
+        }
+
         try {
             $processedObject = Convert-ContextObjectToHashtableRecursive $Context
+            $processedObject['ID'] = $ID
             return ($processedObject | ConvertTo-Json -Depth 100 -Compress)
         } catch {
             Write-Error $_

--- a/src/functions/public/Context/Get-Context.ps1
+++ b/src/functions/public/Context/Get-Context.ps1
@@ -29,33 +29,44 @@ filter Get-Context {
         [string] $ID
     )
 
-    try {
-        $contextVault = Get-ContextVault
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Verbose "[$commandName] - Start"
+        $null = Get-ContextVault
+        $vaultName = $script:Config.VaultName
+    }
 
-        if (-not $PSBoundParameters.ContainsKey('ID')) {
-            Write-Verbose "Retrieving all contexts from [$($contextVault.Name)]"
-            $contexts = Get-SecretInfo -Vault $contextVault.Name
-        } elseif ([string]::IsNullOrEmpty($ID)) {
-            Write-Verbose "Return 0 contexts from [$($contextVault.Name)]"
-            return
-        } elseif ($ID.Contains('*')) {
-            # If wildcards are used, we can use the -Name parameter to filter the results. Its using the -like operator internally in the module.
-            Write-Verbose "Retrieving contexts matching [$ID] from [$($contextVault.Name)]"
-            $contexts = Get-SecretInfo -Vault $contextVault.Name -Name "$($script:Config.SecretPrefix)$ID"
-        } else {
-            # Needs to use Where-Object in order to support special characters, like `[` and `]`.
-            Write-Verbose "Retrieving context [$ID] from [$($contextVault.Name)]"
-            $contexts = Get-SecretInfo -Vault $contextVault.Name | Where-Object { $_.Name -eq "$($script:Config.SecretPrefix)$ID" }
-        }
+    process {
+        try {
+            if (-not $PSBoundParameters.ContainsKey('ID')) {
+                Write-Verbose "Retrieving all contexts from [$vaultName]"
+                $contexts = Get-SecretInfo -Vault $vaultName
+            } elseif ([string]::IsNullOrEmpty($ID)) {
+                Write-Verbose "Return 0 contexts from [$vaultName]"
+                return
+            } elseif ($ID.Contains('*')) {
+                # If wildcards are used, we can use the -Name parameter to filter the results. Its using the -like operator internally in the module.
+                Write-Verbose "Retrieving contexts matching [$ID] from [$vaultName]"
+                $contexts = Get-SecretInfo -Vault $vaultName -Name "$($script:Config.SecretPrefix)$ID"
+            } else {
+                # Needs to use Where-Object in order to support special characters, like `[` and `]`.
+                Write-Verbose "Retrieving context [$ID] from [$vaultName]"
+                $contexts = Get-SecretInfo -Vault $vaultName | Where-Object { $_.Name -eq "$($script:Config.SecretPrefix)$ID" }
+            }
 
-        Write-Verbose "Found [$($contexts.Count)] contexts in [$($contextVault.Name)]"
-        $contexts | ForEach-Object {
-            Write-Verbose " - $($_.Name)"
-            $contextJson = $_ | Get-Secret -AsPlainText
-            ConvertFrom-ContextJson -JsonString $contextJson
+            Write-Verbose "Found [$($contexts.Count)] contexts in [$vaultName]"
+            $contexts | ForEach-Object {
+                Write-Verbose " - $($_.Name)"
+                $contextJson = $_ | Get-Secret -AsPlainText
+                ConvertFrom-ContextJson -JsonString $contextJson
+            }
+        } catch {
+            Write-Error $_
+            throw 'Failed to get context'
         }
-    } catch {
-        Write-Error $_
-        throw 'Failed to get context'
+    }
+
+    end {
+        Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/public/Context/Get-Context.ps1
+++ b/src/functions/public/Context/Get-Context.ps1
@@ -77,7 +77,9 @@ Register-ArgumentCompleter -CommandName Get-Context -ParameterName ID -ScriptBlo
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
 
-    Get-Context | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+    Get-SecretInfo -Vault $vaultName | Where-Object { $_.Name -like "$($script:Config.SecretPrefix)$wordToComplete*" } | ForEach-Object {
+        $Name = $_.Name -replace "^$($script:Config.SecretPrefix)"
+        [System.Management.Automation.CompletionResult]::new($Name, $Name, 'ParameterValue', $Name)
     }
 }
+

--- a/src/functions/public/Context/Get-Context.ps1
+++ b/src/functions/public/Context/Get-Context.ps1
@@ -60,9 +60,7 @@ filter Get-Context {
             $contexts | ForEach-Object {
                 Write-Verbose " - $($_.Name)"
                 $contextJson = $_ | Get-Secret -AsPlainText
-                $contextObj = ConvertFrom-ContextJson -JsonString $contextJson
-                $contextObj | Add-Member -NotePropertyName 'ContextID' -NotePropertyValue $ID -Force
-                $contextObj
+                ConvertFrom-ContextJson -JsonString $contextJson
             }
         } catch {
             Write-Error $_

--- a/src/functions/public/Context/Get-Context.ps1
+++ b/src/functions/public/Context/Get-Context.ps1
@@ -55,6 +55,7 @@ filter Get-Context {
             ConvertFrom-ContextJson -JsonString $contextJson
         }
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to get context'
     }
 }

--- a/src/functions/public/Context/Get-Context.ps1
+++ b/src/functions/public/Context/Get-Context.ps1
@@ -60,7 +60,9 @@ filter Get-Context {
             $contexts | ForEach-Object {
                 Write-Verbose " - $($_.Name)"
                 $contextJson = $_ | Get-Secret -AsPlainText
-                ConvertFrom-ContextJson -JsonString $contextJson
+                $contextObj = ConvertFrom-ContextJson -JsonString $contextJson
+                $contextObj | Add-Member -NotePropertyName 'ContextID' -NotePropertyValue $ID -Force
+                $contextObj
             }
         } catch {
             Write-Error $_

--- a/src/functions/public/Context/Get-Context.ps1
+++ b/src/functions/public/Context/Get-Context.ps1
@@ -31,7 +31,7 @@ filter Get-Context {
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
         $null = Get-ContextVault
         $vaultName = $script:Config.VaultName
         $secretPrefix = $script:Config.SecretPrefix
@@ -69,7 +69,7 @@ filter Get-Context {
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }
 

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -32,7 +32,7 @@ filter Remove-Context {
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
         $null = Get-ContextVault
         $vaultName = $script:Config.VaultName
         $secretPrefix = $script:Config.SecretPrefix
@@ -52,7 +52,7 @@ filter Remove-Context {
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }
 

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -38,6 +38,7 @@ filter Remove-Context {
             Get-SecretInfo -Vault $script:Config.VaultName | Where-Object { $_.Name -eq $ID } | Remove-Secret
         }
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to remove context'
     }
 }

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -30,15 +30,27 @@ filter Remove-Context {
         [string] $ID
     )
 
-    try {
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Verbose "[$commandName] - Start"
         $null = Get-ContextVault
-        $ID = "$($script:Config.SecretPrefix)$ID"
+        $vaultName = $script:Config.VaultName
+    }
 
-        if ($PSCmdlet.ShouldProcess('Remove-Secret', $context.Name)) {
-            Get-SecretInfo -Vault $script:Config.VaultName | Where-Object { $_.Name -eq $ID } | Remove-Secret
+    process {
+        try {
+            $ID = "$($script:Config.SecretPrefix)$ID"
+
+            if ($PSCmdlet.ShouldProcess('Remove-Secret', $context.Name)) {
+                Get-SecretInfo -Vault $vaultName | Where-Object { $_.Name -eq $ID } | Remove-Secret
+            }
+        } catch {
+            Write-Error $_
+            throw 'Failed to remove context'
         }
-    } catch {
-        Write-Error $_
-        throw 'Failed to remove context'
+    }
+
+    end {
+        Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -35,14 +35,15 @@ filter Remove-Context {
         Write-Verbose "[$commandName] - Start"
         $null = Get-ContextVault
         $vaultName = $script:Config.VaultName
+        $secretPrefix = $script:Config.SecretPrefix
+        $fullID = "$secretPrefix$ID"
     }
 
     process {
         try {
-            $ID = "$($script:Config.SecretPrefix)$ID"
 
-            if ($PSCmdlet.ShouldProcess('Remove-Secret', $context.Name)) {
-                Get-SecretInfo -Vault $vaultName | Where-Object { $_.Name -eq $ID } | Remove-Secret
+            if ($PSCmdlet.ShouldProcess($fullID, 'Remove secret')) {
+                Get-SecretInfo -Vault $vaultName | Where-Object { $_.Name -eq $fullID } | Remove-Secret
             }
         } catch {
             Write-Error $_
@@ -52,5 +53,14 @@ filter Remove-Context {
 
     end {
         Write-Verbose "[$commandName] - End"
+    }
+}
+
+Register-ArgumentCompleter -CommandName Remove-Context -ParameterName ID -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+    $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
+
+    Get-Context | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
     }
 }

--- a/src/functions/public/Context/Remove-Context.ps1
+++ b/src/functions/public/Context/Remove-Context.ps1
@@ -60,7 +60,8 @@ Register-ArgumentCompleter -CommandName Remove-Context -ParameterName ID -Script
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
 
-    Get-Context | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+    Get-SecretInfo -Vault $vaultName | Where-Object { $_.Name -like "$($script:Config.SecretPrefix)$wordToComplete*" } | ForEach-Object {
+        $Name = $_.Name -replace "^$($script:Config.SecretPrefix)"
+        [System.Management.Automation.CompletionResult]::new($Name, $Name, 'ParameterValue', $Name)
     }
 }

--- a/src/functions/public/Context/Rename-Context.ps1
+++ b/src/functions/public/Context/Rename-Context.ps1
@@ -1,0 +1,59 @@
+﻿function Rename-Context {
+    <#
+        .SYNOPSIS
+        Renames a context.
+
+        .DESCRIPTION
+        This function renames a context.
+        It retrieves the context with the old ID, sets the context with the new ID, and removes the context with the old ID.
+
+        .EXAMPLE
+        Example of how to use the function or script.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        # The ID of the context to rename.
+        [Parameter(Mandatory)]
+        [string] $ID,
+
+        # The new ID of the context.
+        [Parameter(Mandatory)]
+        [string] $NewID
+    )
+
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Debug "[$commandName] - Start"
+        $context = Get-Context -ID $ID
+        if (-not $context) {
+            throw "Context with ID '$ID' not found."
+        }
+
+        $existingContext = Get-Context -ID $NewID
+        if ($existingContext) {
+            throw "Context with ID '$NewID' already exists."
+        }
+    }
+
+    process {
+        if ($PSCmdlet.ShouldProcess("Renaming context '$ID' to '$NewID'")) {
+            try {
+                Set-Context -ID $NewID -Context $context
+            } catch {
+                Write-Error $_
+                throw 'Failed to set new context'
+            }
+
+            try {
+                Remove-Context -ID $ID
+            } catch {
+                Write-Error $_
+                throw 'Failed to remove old context'
+            }
+        }
+    }
+
+    end {
+        Write-Debug "[$commandName] - End"
+    }
+}

--- a/src/functions/public/Context/Set-Context.ps1
+++ b/src/functions/public/Context/Set-Context.ps1
@@ -36,27 +36,27 @@ function Set-Context {
         Write-Debug "[$commandName] - Start"
         $null = Get-ContextVault
         $vaultName = $script:Config.VaultName
+        $secretPrefix = $script:Config.SecretPrefix
+        $fullID = "$secretPrefix$ID"
     }
 
     process {
         try {
-            $secret = ConvertTo-ContextJson -Context $Context
+            $secret = ConvertTo-ContextJson -Context $Context -ID $fullID
         } catch {
             Write-Error $_
             throw 'Failed to convert context to JSON'
         }
 
-        $Name = "$($script:Config.SecretPrefix)$ID"
-
         $param = @{
-            Name   = $Name
+            Name   = $fullID
             Secret = $secret
             Vault  = $vaultName
         }
         Write-Verbose ($param | ConvertTo-Json -Depth 5)
 
         try {
-            if ($PSCmdlet.ShouldProcess($Name, 'Set Secret')) {
+            if ($PSCmdlet.ShouldProcess($fullID, 'Set Secret')) {
                 Set-Secret @param
             }
         } catch {

--- a/src/functions/public/Context/Set-Context.ps1
+++ b/src/functions/public/Context/Set-Context.ps1
@@ -46,15 +46,17 @@ function Set-Context {
             throw 'Failed to convert context to JSON'
         }
 
+        $Name = "$($script:Config.SecretPrefix)$ID"
+
         $param = @{
-            Name   = "$($script:Config.SecretPrefix)$ID"
+            Name   = $Name
             Secret = $secret
             Vault  = $vaultName
         }
         Write-Verbose ($param | ConvertTo-Json -Depth 5)
 
         try {
-            if ($PSCmdlet.ShouldProcess('Set-Secret', $param)) {
+            if ($PSCmdlet.ShouldProcess($Name, 'Set Secret')) {
                 Set-Secret @param
             }
         } catch {

--- a/src/functions/public/Context/Set-Context.ps1
+++ b/src/functions/public/Context/Set-Context.ps1
@@ -31,19 +31,28 @@ function Set-Context {
         [object] $Context
     )
 
+    $contextVault = Get-ContextVault
+
     try {
-        $contextVault = Get-ContextVault
+        $secret = ConvertTo-ContextJson -Context $Context
+    } catch {
+        Write-Error $_
+        throw 'Failed to convert context to JSON'
+    }
 
-        $param = @{
-            Name   = "$($script:Config.SecretPrefix)$ID"
-            Secret = ConvertTo-ContextJson -Context $Context
-            Vault  = $contextVault.Name
-        }
+    $param = @{
+        Name   = "$($script:Config.SecretPrefix)$ID"
+        Secret = $secret
+        Vault  = $contextVault.Name
+    }
+    Write-Verbose ($param | ConvertTo-Json -Depth 5)
 
+    try {
         if ($PSCmdlet.ShouldProcess('Set-Secret', $param)) {
             Set-Secret @param
         }
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to set secret'
     }
 }

--- a/src/functions/public/Context/Set-Context.ps1
+++ b/src/functions/public/Context/Set-Context.ps1
@@ -33,7 +33,7 @@ function Set-Context {
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
         $null = Get-ContextVault
         $vaultName = $script:Config.VaultName
     }
@@ -66,6 +66,6 @@ function Set-Context {
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }

--- a/src/functions/public/ContextSetting/Get-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Get-ContextSetting.ps1
@@ -28,7 +28,7 @@ function Get-ContextSetting {
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
         $null = Get-ContextVault
     }
 
@@ -49,7 +49,7 @@ function Get-ContextSetting {
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }
 

--- a/src/functions/public/ContextSetting/Get-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Get-ContextSetting.ps1
@@ -52,3 +52,23 @@ function Get-ContextSetting {
         Write-Verbose "[$commandName] - End"
     }
 }
+
+Register-ArgumentCompleter -CommandName Get-ContextSetting -ParameterName ID -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+    $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
+
+    Get-Context | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+    }
+}
+
+Register-ArgumentCompleter -CommandName Get-ContextSetting -ParameterName Name -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+    $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
+
+    Get-Context -ID $fakeBoundParameter.ID | ForEach-Object {
+        $_.PSObject.Properties | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+        }
+    }
+}

--- a/src/functions/public/ContextSetting/Get-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Get-ContextSetting.ps1
@@ -57,8 +57,9 @@ Register-ArgumentCompleter -CommandName Get-ContextSetting -ParameterName ID -Sc
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
 
-    Get-Context | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+    Get-SecretInfo -Vault $vaultName | Where-Object { $_.Name -like "$($script:Config.SecretPrefix)$wordToComplete*" } | ForEach-Object {
+        $Name = $_.Name -replace "^$($script:Config.SecretPrefix)"
+        [System.Management.Automation.CompletionResult]::new($Name, $Name, 'ParameterValue', $Name)
     }
 }
 

--- a/src/functions/public/ContextSetting/Get-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Get-ContextSetting.ps1
@@ -26,18 +26,29 @@ function Get-ContextSetting {
         [string] $Name
     )
 
-    try {
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Verbose "[$commandName] - Start"
         $null = Get-ContextVault
-        $context = Get-Context -ID $ID
+    }
 
-        if (-not $context) {
-            throw "Context [$ID] not found"
+    process {
+        try {
+            $context = Get-Context -ID $ID
+
+            if (-not $context) {
+                throw "Context [$ID] not found"
+            }
+
+            Write-Verbose "Returning setting: [$Name]"
+            $context.$Name
+        } catch {
+            Write-Error $_
+            throw 'Failed to get context setting'
         }
+    }
 
-        Write-Verbose "Returning setting: [$Name]"
-        $context.$Name
-    } catch {
-        Write-Error $_
-        throw 'Failed to get context setting'
+    end {
+        Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/public/ContextSetting/Get-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Get-ContextSetting.ps1
@@ -37,6 +37,7 @@ function Get-ContextSetting {
         Write-Verbose "Returning setting: [$Name]"
         $context.$Name
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to get context setting'
     }
 }

--- a/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
@@ -73,3 +73,23 @@ filter Remove-ContextSetting {
         Write-Verbose "[$commandName] - End"
     }
 }
+
+Register-ArgumentCompleter -CommandName Remove-ContextSetting -ParameterName ID -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+    $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
+
+    Get-Context | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+    }
+}
+
+Register-ArgumentCompleter -CommandName Get-ContextSetting -ParameterName Name -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+    $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
+
+    Get-Context -ID $fakeBoundParameter.ID | ForEach-Object {
+        $_.PSObject.Properties | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+        }
+    }
+}

--- a/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
@@ -47,7 +47,7 @@ filter Remove-ContextSetting {
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
     }
 
     process {
@@ -70,7 +70,7 @@ filter Remove-ContextSetting {
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }
 

--- a/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
@@ -78,8 +78,9 @@ Register-ArgumentCompleter -CommandName Remove-ContextSetting -ParameterName ID 
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
 
-    Get-Context | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+    Get-SecretInfo -Vault $vaultName | Where-Object { $_.Name -like "$($script:Config.SecretPrefix)$wordToComplete*" } | ForEach-Object {
+        $Name = $_.Name -replace "^$($script:Config.SecretPrefix)"
+        [System.Management.Automation.CompletionResult]::new($Name, $Name, 'ParameterValue', $Name)
     }
 }
 

--- a/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
@@ -45,21 +45,31 @@ filter Remove-ContextSetting {
         [string] $ID
     )
 
-    try {
-        $null = Get-ContextVault
-        $context = Get-Context -ID $ID
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Verbose "[$commandName] - Start"
+    }
 
-        if (-not $context) {
-            throw "Context [$ID] not found"
-        }
+    process {
+        try {
+            $context = Get-Context -ID $ID
 
-        if ($PSCmdlet.ShouldProcess("[$($context.Name)]", "Remove [$Name]")) {
-            Write-Verbose "Setting [$Name] in [$($context.Name)]"
-            $context.PSObject.Properties.Remove($Name)
-            Set-Context -Context $context -ID $ID
+            if (-not $context) {
+                throw "Context [$ID] not found"
+            }
+
+            if ($PSCmdlet.ShouldProcess("[$($context.Name)]", "Remove [$Name]")) {
+                Write-Verbose "Setting [$Name] in [$($context.Name)]"
+                $context.PSObject.Properties.Remove($Name)
+                Set-Context -Context $context -ID $ID
+            }
+        } catch {
+            Write-Error $_
+            throw 'Failed to remove context setting'
         }
-    } catch {
-        Write-Error $_
-        throw 'Failed to remove context setting'
+    }
+
+    end {
+        Write-Verbose "[$commandName] - End"
     }
 }

--- a/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Remove-ContextSetting.ps1
@@ -59,6 +59,7 @@ filter Remove-ContextSetting {
             Set-Context -Context $context -ID $ID
         }
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to remove context setting'
     }
 }

--- a/src/functions/public/ContextSetting/Set-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Set-ContextSetting.ps1
@@ -76,7 +76,8 @@ Register-ArgumentCompleter -CommandName Get-ContextSetting -ParameterName ID -Sc
     param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
     $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
 
-    Get-Context | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+    Get-SecretInfo -Vault $vaultName | Where-Object { $_.Name -like "$($script:Config.SecretPrefix)$wordToComplete*" } | ForEach-Object {
+        $Name = $_.Name -replace "^$($script:Config.SecretPrefix)"
+        [System.Management.Automation.CompletionResult]::new($Name, $Name, 'ParameterValue', $Name)
     }
 }

--- a/src/functions/public/ContextSetting/Set-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Set-ContextSetting.ps1
@@ -57,6 +57,7 @@ function Set-ContextSetting {
             Set-Context -Context $context -ID $ID
         }
     } catch {
-        throw $_
+        Write-Error $_
+        throw 'Failed to set context setting'
     }
 }

--- a/src/functions/public/ContextSetting/Set-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Set-ContextSetting.ps1
@@ -41,7 +41,7 @@ function Set-ContextSetting {
 
     begin {
         $commandName = $MyInvocation.MyCommand.Name
-        Write-Verbose "[$commandName] - Start"
+        Write-Debug "[$commandName] - Start"
     }
 
     process {
@@ -68,7 +68,7 @@ function Set-ContextSetting {
     }
 
     end {
-        Write-Verbose "[$commandName] - End"
+        Write-Debug "[$commandName] - End"
     }
 }
 

--- a/src/functions/public/ContextSetting/Set-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Set-ContextSetting.ps1
@@ -71,3 +71,12 @@ function Set-ContextSetting {
         Write-Verbose "[$commandName] - End"
     }
 }
+
+Register-ArgumentCompleter -CommandName Get-ContextSetting -ParameterName ID -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+    $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter
+
+    Get-Context | Where-Object { $_.Name -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, 'ParameterValue', $_.Name)
+    }
+}

--- a/src/functions/public/ContextSetting/Set-ContextSetting.ps1
+++ b/src/functions/public/ContextSetting/Set-ContextSetting.ps1
@@ -39,25 +39,35 @@ function Set-ContextSetting {
         [string] $ID
     )
 
-    try {
-        $null = Get-ContextVault
-        $context = Get-Context -ID $ID
+    begin {
+        $commandName = $MyInvocation.MyCommand.Name
+        Write-Verbose "[$commandName] - Start"
+    }
 
-        if (-not $context) {
-            throw "Context [$ID] not found"
-        }
+    process {
+        try {
+            $context = Get-Context -ID $ID
 
-        if ($PSCmdlet.ShouldProcess($Name, "Set value [$Value]")) {
-            Write-Verbose "Setting [$Name] to [$Value] in [$ID]"
-            if ($context.PSObject.Properties[$Name]) {
-                $context.$Name = $Value
-            } else {
-                $context | Add-Member -NotePropertyName $Name -NotePropertyValue $Value -Force
+            if (-not $context) {
+                throw "Context [$ID] not found"
             }
-            Set-Context -Context $context -ID $ID
+
+            if ($PSCmdlet.ShouldProcess($Name, "Set value [$Value]")) {
+                Write-Verbose "Setting [$Name] to [$Value] in [$ID]"
+                if ($context.PSObject.Properties[$Name]) {
+                    $context.$Name = $Value
+                } else {
+                    $context | Add-Member -NotePropertyName $Name -NotePropertyValue $Value -Force
+                }
+                Set-Context -Context $context -ID $ID
+            }
+        } catch {
+            Write-Error $_
+            throw 'Failed to set context setting'
         }
-    } catch {
-        Write-Error $_
-        throw 'Failed to set context setting'
+    }
+
+    end {
+        Write-Verbose "[$commandName] - End"
     }
 }

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -110,9 +110,6 @@ Describe 'Private functions' {
 
 Describe 'Context' {
     Context 'Function: Set-Context' {
-        It 'Function is be available' {
-            Get-Command -Name 'Set-Context' | Should -Not -BeNullOrEmpty
-        }
         It 'Set-Context -Context $Context - Value is not empty' {
             $Context = @{
                 Name = 'TestName'
@@ -155,10 +152,6 @@ Describe 'Context' {
     }
 
     Context 'Function: Get-Context' {
-        It 'Function is be available' {
-            Get-Command -Name 'Get-Context' | Should -Not -BeNullOrEmpty
-        }
-
         It 'Get-Context - Should return all contexts' {
             (Get-Context).Count | Should -BeGreaterOrEqual 3
         }
@@ -178,10 +171,6 @@ Describe 'Context' {
     }
 
     Context 'Function: Remove-Context' {
-        It 'Function is be available' {
-            Get-Command -Name 'Remove-Context' | Should -Not -BeNullOrEmpty
-        }
-
         It 'Remove-Context -Name $Name - Should remove the context' {
             Get-SecretInfo | Remove-Secret
 
@@ -199,7 +188,7 @@ Describe 'Context' {
         }
     }
 
-    Context 'Other' {
+    Context 'Scenarios' {
         It 'Context can hold a complex object' {
             $githubLoginContext = [PSCustomObject]@{
                 Username          = 'john_doe'
@@ -264,6 +253,10 @@ Describe 'Context' {
                     }
                 }
             }
+
+            # Test to see if it can be run multiple times
+            Set-Context -Context $githubLoginContext -ID 'BigComplexObject'
+            Set-Context -Context $githubLoginContext -ID 'BigComplexObject'
             Set-Context -Context $githubLoginContext -ID 'BigComplexObject'
             Write-Verbose (Get-Secret -Name 'Context:BigComplexObject' -AsPlainText) -Verbose
             $object = Get-Context -ID 'BigComplexObject'
@@ -337,12 +330,13 @@ Describe 'Context' {
 
             { Remove-Context -ID 'MyModule/ThisIsATest[bot]' } | Should -Not -Throw
         }
+        It 'Only lists context, not other secrets' {
+            Set-Secret -Name 'Test' -Secret 'Test'
+            Get-Context
+        }
     }
 
     Context 'Set-ContextSetting' {
-        It 'Should be available' {
-            Get-Command -Name 'Set-ContextSetting' | Should -Not -BeNullOrEmpty
-        }
         It "Set-ContextSetting -Name 'Test' -Value 'Test' -ID 'TestContext'" {
             Get-SecretInfo | Remove-Secret
 
@@ -381,9 +375,6 @@ Describe 'Context' {
         }
     }
     Context 'Get-ContextSetting' {
-        It 'Should be available' {
-            Get-Command -Name 'Get-ContextSetting' | Should -Not -BeNullOrEmpty
-        }
         It "Get-ContextSetting -Name 'Test' -ID 'Test'" {
             Write-Verbose 'Setup: Create a Context'
             Set-Context -Context @{ Name = 'Test'; Secret = 'Test' } -ID 'Test'
@@ -405,9 +396,6 @@ Describe 'Context' {
         }
     }
     Context 'Remove-ContextSetting' {
-        It 'Should be available' {
-            Get-Command -Name 'Remove-ContextSetting' | Should -Not -BeNullOrEmpty
-        }
         It "Remove-ContextSetting -Name 'Test' -ID 'Test'" {
             Write-Verbose 'Setup: Create a Context'
             Set-Context -Context @{ Name = 'Test'; Secret = 'Test' } -ID 'Test'

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -332,7 +332,7 @@ Describe 'Context' {
         }
         It 'Only lists context, not other secrets' {
             Set-Secret -Name 'Test' -Secret 'Test'
-            Set-Context -ID 'Test' -Context @{ Name = 'Test'}
+            Set-Context -ID 'Test' -Context @{ Name = 'Test' }
             $result = Get-Context
             Write-Verbose ($result | Out-String) -Verbose
             $result.Count | Should -Be 1

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -119,6 +119,7 @@ Describe 'Context' {
             $result = Get-Context -ID 'TestID'
             $result | Should -Not -BeNullOrEmpty
             $result.Name | Should -Be 'TestName'
+            $result.ID | Should -Be 'Context:TestID'
         }
         It 'Set-Context -Context $Context - Context can hold a bigger object' {
             $Context = @{
@@ -133,6 +134,7 @@ Describe 'Context' {
             $result.Count | Should -Be 1
             $result | Should -Not -BeNullOrEmpty
             $result.AccessToken | Should -Be 'MySecret'
+            $result.ID | Should -Be 'Context:TestID2'
         }
         It 'Set-Context -Context $Context - Context can be saved multiple times' {
             $Context = @{
@@ -148,23 +150,28 @@ Describe 'Context' {
             $result | Should -Not -BeNullOrEmpty
             $result.AccessToken | Should -Be 'MySecret'
             $result.RefreshToken | Should -Be 'MyRefreshedSecret'
+            $result.ID | Should -Be 'Context:TestID3'
         }
     }
 
     Context 'Function: Get-Context' {
         It 'Get-Context - Should return all contexts' {
+            Write-Verbose (Get-Context | Out-String) -Verbose
             (Get-Context).Count | Should -BeGreaterOrEqual 3
         }
 
         It "Get-Context -ID '*' - Should return all contexts" {
+            Write-Verbose (Get-Context -ID '*' | Out-String) -Verbose
             (Get-Context -ID '*').Count | Should -BeGreaterOrEqual 3
         }
 
         It "Get-Context -ID '' - Should return no contexts" {
+            Write-Verbose (Get-Context -ID '' | Out-String) -Verbose
             { Get-Context -ID '' } | Should -Not -Throw
             Get-Context -ID '' | Should -BeNullOrEmpty
         }
         It 'Get-Context -ID $null - Should return no contexts' {
+            Write-Verbose (Get-Context -ID $null | Out-String) -Verbose
             { Get-Context -ID $null } | Should -Not -Throw
             Get-Context -ID $null | Should -BeNullOrEmpty
         }
@@ -380,6 +387,7 @@ Describe 'Context' {
             Remove-Context -ID 'TestSomething'
         }
     }
+
     Context 'Get-ContextSetting' {
         It "Get-ContextSetting -Name 'Test' -ID 'Test'" {
             Write-Verbose 'Setup: Create a Context'
@@ -401,6 +409,7 @@ Describe 'Context' {
             { Get-ContextSetting -Name 'Test' -ID 'Test55' } | Should -Throw -Because 'Context does not exist'
         }
     }
+
     Context 'Remove-ContextSetting' {
         It "Remove-ContextSetting -Name 'Test' -ID 'Test'" {
             Write-Verbose 'Setup: Create a Context'

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -349,6 +349,55 @@ Describe 'Context' {
         }
     }
 
+    Context 'Function: Rename-Context' {
+
+        BeforeAll {
+            # Ensure no contexts exist before starting tests
+            Get-Context | ForEach-Object {
+                Remove-Context -ID $_.ID
+            }
+        }
+
+        AfterAll {
+            # Cleanup any contexts created during tests
+            Get-Context | ForEach-Object {
+                Remove-Context -ID $_.ID
+            }
+        }
+
+        Context 'Renaming an existing context' {
+            It 'Renames the context successfully' {
+                $oldID = 'TestContext'
+                $newID = 'RenamedContext'
+
+                # Create a context to rename
+                $contextData = @{
+                    Name  = 'TestName'
+                    Value = 'TestValue'
+                }
+                Set-Context -ID $oldID -Context $contextData
+
+                # Rename the context
+                Rename-Context -OldID $oldID -NewID $newID
+
+                # Verify the old context no longer exists
+                Get-Context -ID $oldID | Should -BeNullOrEmpty
+
+                # Verify the new context exists with correct data
+                $renamedContext = Get-Context -ID $newID
+                $renamedContext | Should -Not -BeNullOrEmpty
+                $renamedContext.Name | Should -Be 'TestName'
+                $renamedContext.Value | Should -Be 'TestValue'
+            }
+        }
+
+        Context 'Renaming a non-existent context' {
+            It 'Throws an error' {
+                { Rename-Context -OldID 'NonExistentContext' -NewID 'NewContext' } | Should -Throw
+            }
+        }
+    }
+
     Context 'Set-ContextSetting' {
         It "Set-ContextSetting -Name 'Test' -Value 'Test' -ID 'TestContext'" {
             Get-SecretInfo | Remove-Secret

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -332,7 +332,13 @@ Describe 'Context' {
         }
         It 'Only lists context, not other secrets' {
             Set-Secret -Name 'Test' -Secret 'Test'
-            Get-Context
+            Set-Context -ID 'Test' -Context @{ Name = 'Test'}
+            $result = Get-Context
+            Write-Verbose ($result | Out-String) -Verbose
+            $result.Count | Should -Be 1
+
+            Remove-Context -ID 'Test'
+            Get-SecretInfo -Name 'Test' | Remove-Secret
         }
     }
 

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -378,7 +378,7 @@ Describe 'Context' {
                 Set-Context -ID $oldID -Context $contextData
 
                 # Rename the context
-                Rename-Context -OldID $oldID -NewID $newID
+                Rename-Context -ID $oldID -NewID $newID
 
                 # Verify the old context no longer exists
                 Get-Context -ID $oldID | Should -BeNullOrEmpty
@@ -393,7 +393,7 @@ Describe 'Context' {
 
         Context 'Renaming a non-existent context' {
             It 'Throws an error' {
-                { Rename-Context -OldID 'NonExistentContext' -NewID 'NewContext' } | Should -Throw
+                { Rename-Context -ID 'NonExistentContext' -NewID 'NewContext' } | Should -Throw
             }
         }
     }


### PR DESCRIPTION
## Description

- Fixed an issue where the data type of a value was not accessible to Write-Debug.
- Improved error handling in context vault functions by adding a custom error message and using Write-Error to log the error.
- Fixed an issue where `Get-Context` would retrieve all secrets instead of only those prefixed with 'Context:' (i.e., the ones the module manages).
- Add a function for renaming existing contexts, `Rename-Context`, and corresponding tests.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
