### PR TITLE
🪲 [Fix]: Remove check of existing context in `Rename-Context`

### DIFF
--- a/src/functions/public/Context/Rename-Context.ps1
+++ b/src/functions/public/Context/Rename-Context.ps1
@@ -18,7 +18,11 @@
 
         # The new ID of the context.
         [Parameter(Mandatory)]
-        [string] $NewID
+        [string] $NewID,
+
+        # Force the rename even if the new ID already exists.
+        [Parameter()]
+        [switch] $Force
     )
 
     begin {
@@ -27,6 +31,11 @@
         $context = Get-Context -ID $ID
         if (-not $context) {
             throw "Context with ID '$ID' not found."
+        }
+
+        $existingContext = Get-Context -ID $NewID
+        if ($existingContext -and -not $Force) {
+            throw "Context with ID '$NewID' already exists."
         }
     }
 

--- a/src/functions/public/Context/Rename-Context.ps1
+++ b/src/functions/public/Context/Rename-Context.ps1
@@ -28,11 +28,6 @@
         if (-not $context) {
             throw "Context with ID '$ID' not found."
         }
-
-        $existingContext = Get-Context -ID $NewID
-        if ($existingContext) {
-            throw "Context with ID '$NewID' already exists."
-        }
     }
 
     process {

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -365,40 +365,80 @@ Describe 'Context' {
             }
         }
 
-        Context 'Renaming an existing context' {
-            It 'Renames the context successfully' {
-                $oldID = 'TestContext'
-                $newID = 'RenamedContext'
+        It 'Renames the context successfully' {
+            $oldID = 'TestContext'
+            $newID = 'RenamedContext'
 
-                # Create a context to rename
-                $contextData = @{
-                    Name  = 'TestName'
-                    Value = 'TestValue'
-                }
-                Set-Context -ID $oldID -Context $contextData
-
-                # Rename the context
-                Rename-Context -ID $oldID -NewID $newID
-
-                # Verify the old context no longer exists
-                Get-Context -ID $oldID | Should -BeNullOrEmpty
-
-                # Verify the new context exists with correct data
-                $renamedContext = Get-Context -ID $newID
-                $renamedContext | Should -Not -BeNullOrEmpty
-                $renamedContext.Name | Should -Be 'TestName'
-                $renamedContext.Value | Should -Be 'TestValue'
+            # Create a context to rename
+            $contextData = @{
+                Name  = 'TestName'
+                Value = 'TestValue'
             }
+            Set-Context -ID $oldID -Context $contextData
+
+            # Rename the context
+            Rename-Context -ID $oldID -NewID $newID
+
+            # Verify the old context no longer exists
+            Get-Context -ID $oldID | Should -BeNullOrEmpty
+
+            # Verify the new context exists with correct data
+            $renamedContext = Get-Context -ID $newID
+            $renamedContext | Should -Not -BeNullOrEmpty
+            $renamedContext.Name | Should -Be 'TestName'
+            $renamedContext.Value | Should -Be 'TestValue'
         }
 
-        Context 'Renaming a non-existent context' {
-            It 'Throws an error' {
-                { Rename-Context -ID 'NonExistentContext' -NewID 'NewContext' } | Should -Throw
+        It 'Throws an error when renaming a non-existent context' {
+            { Rename-Context -ID 'NonExistentContext' -NewID 'NewContext' } | Should -Throw
+        }
+
+        It 'Renaming a context to an existing context throws without force' {
+            $existingID = 'ExistingContext'
+            $newID = 'ExistingContext'
+
+            # Create an existing context
+            $contextData = @{
+                Name  = 'ExistingName'
+                Value = 'ExistingValue'
             }
+            Set-Context -ID $existingID -Context $contextData
+
+            # Create a context to rename
+            $contextData = @{
+                Name  = 'TestName'
+                Value = 'TestValue'
+            }
+            Set-Context -ID 'TestContext' -Context $contextData
+
+            # Attempt to rename the context to an existing context
+            { Rename-Context -ID 'TestContext' -NewID $newID } | Should -Throw
+        }
+
+        It 'Renaming a context to an existing context does not throw with force' {
+            $existingID = 'ExistingContext'
+            $newID = 'ExistingContext'
+
+            # Create an existing context
+            $contextData = @{
+                Name  = 'ExistingName'
+                Value = 'ExistingValue'
+            }
+            Set-Context -ID $existingID -Context $contextData
+
+            # Create a context to rename
+            $contextData = @{
+                Name  = 'TestName'
+                Value = 'TestValue'
+            }
+            Set-Context -ID 'TestContext' -Context $contextData
+
+            # Attempt to rename the context to an existing context
+            { Rename-Context -ID 'TestContext' -NewID $newID -Force } | Should -Not -Throw
         }
     }
 
-    Context 'Set-ContextSetting' {
+    Context 'Function: Set-ContextSetting' {
         It "Set-ContextSetting -Name 'Test' -Value 'Test' -ID 'TestContext'" {
             Get-SecretInfo | Remove-Secret
 
@@ -437,7 +477,7 @@ Describe 'Context' {
         }
     }
 
-    Context 'Get-ContextSetting' {
+    Context 'Function: Get-ContextSetting' {
         It "Get-ContextSetting -Name 'Test' -ID 'Test'" {
             Write-Verbose 'Setup: Create a Context'
             Set-Context -Context @{ Name = 'Test'; Secret = 'Test' } -ID 'Test'
@@ -459,7 +499,7 @@ Describe 'Context' {
         }
     }
 
-    Context 'Remove-ContextSetting' {
+    Context 'Function: Remove-ContextSetting' {
         It "Remove-ContextSetting -Name 'Test' -ID 'Test'" {
             Write-Verbose 'Setup: Create a Context'
             Set-Context -Context @{ Name = 'Test'; Secret = 'Test' } -ID 'Test'


### PR DESCRIPTION
## Description

- Remove check of existing context in `Rename-Context`

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
