### PR TITLE
🩹 [Patch]: Align StackPath logging with the `GitHub` module

### DIFF
--- a/src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1
+++ b/src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1
@@ -32,8 +32,8 @@
     )
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
     }
 
     process {
@@ -76,6 +76,6 @@
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }

--- a/src/functions/private/JsonToObject/ConvertFrom-ContextJson.ps1
+++ b/src/functions/private/JsonToObject/ConvertFrom-ContextJson.ps1
@@ -29,8 +29,8 @@
     )
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
     }
 
     process {
@@ -44,6 +44,6 @@
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }

--- a/src/functions/private/ObjectToJson/Convert-ContextObjectToHashtableRecursive.ps1
+++ b/src/functions/private/ObjectToJson/Convert-ContextObjectToHashtableRecursive.ps1
@@ -30,8 +30,8 @@
     )
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
     }
 
     process {
@@ -85,6 +85,6 @@
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }

--- a/src/functions/private/ObjectToJson/ConvertTo-ContextJson.ps1
+++ b/src/functions/private/ObjectToJson/ConvertTo-ContextJson.ps1
@@ -36,8 +36,8 @@
     )
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
     }
 
     process {
@@ -52,6 +52,6 @@
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }

--- a/src/functions/private/Set-ContextVault.ps1
+++ b/src/functions/private/Set-ContextVault.ps1
@@ -47,8 +47,8 @@ function Set-ContextVault {
     )
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
     }
 
     process {
@@ -96,6 +96,6 @@ function Set-ContextVault {
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }

--- a/src/functions/private/Utilities/PowerShell/Get-PSCallStackPath.ps1
+++ b/src/functions/private/Utilities/PowerShell/Get-PSCallStackPath.ps1
@@ -1,0 +1,49 @@
+﻿function Get-PSCallStackPath {
+    <#
+        .SYNOPSIS
+        Create a string representation of the current call stack.
+
+        .DESCRIPTION
+        This function creates a string representation of the current call stack.
+        You can use the SkipFirst and SkipLatest parameters to skip the first and last.
+        By default it will skip the first (what called the initial function, typically <ScriptBlock>),
+        and the last (the current function, Get-PSCallStackPath).
+
+        .EXAMPLE
+        Get-PSCallStackPath
+        First-Function\Second-Function\Third-Function
+
+        Shows the call stack of the last function called, Third-Function, with the first (<ScriptBlock>) and last (Get-PSCallStackPath) functions
+        removed.
+
+        .EXAMPLE
+        Get-PSCallStackPath -SkipFirst 0
+        <ScriptBlock>\First-Function\Second-Function\Third-Function
+
+        Shows the call stack of the last function called, Third-Function, with the first function included (typically <ScriptBlock>).
+
+        .EXAMPLE
+        Get-PSCallStackPath -SkipLatest 0
+        First-Function\Second-Function\Third-Function\Get-PSCallStackPath
+
+        Shows the call stack of the last function called, Third-Function, with the last function included (Get-PSCallStackPath).
+    #>
+    [CmdletBinding()]
+    param(
+        # Number of the functions to skip from the last function called.
+        # Last function is this function, Get-PSCallStackPath.
+        [Parameter()]
+        [int] $SkipLatest = 1,
+
+        # Number of the functions to skip from the first function called.
+        # First function is typically <ScriptBlock>.
+        [Parameter()]
+        [int] $SkipFirst = 1
+    )
+    $skipFirst++
+    $cmds = (Get-PSCallStack).Command
+    $functionPath = $cmds[($cmds.Count - $skipFirst)..$SkipLatest] -join '\'
+    $functionPath = $functionPath -replace '^.*<ScriptBlock>\\'
+    $functionPath = $functionPath -replace '^.*.ps1\\'
+    return $functionPath
+}

--- a/src/functions/public/Get-Context.ps1
+++ b/src/functions/public/Get-Context.ps1
@@ -29,8 +29,8 @@ filter Get-Context {
     )
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
         Set-ContextVault
         $vaultName = $script:Config.VaultName
         $contextInfos = Get-ContextInfo
@@ -63,6 +63,6 @@ filter Get-Context {
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }

--- a/src/functions/public/Get-ContextInfo.ps1
+++ b/src/functions/public/Get-ContextInfo.ps1
@@ -16,8 +16,8 @@
     param()
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
         Set-ContextVault
         $vaultName = $script:Config.VaultName
         $secretPrefix = $script:Config.SecretPrefix
@@ -39,6 +39,6 @@
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }

--- a/src/functions/public/Remove-Context.ps1
+++ b/src/functions/public/Remove-Context.ps1
@@ -30,8 +30,8 @@ filter Remove-Context {
     )
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
         Set-ContextVault
     }
 
@@ -51,6 +51,6 @@ filter Remove-Context {
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }

--- a/src/functions/public/Rename-Context.ps1
+++ b/src/functions/public/Rename-Context.ps1
@@ -28,8 +28,8 @@
     )
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
         Set-ContextVault
     }
 
@@ -62,6 +62,6 @@
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }

--- a/src/functions/public/Set-Context.ps1
+++ b/src/functions/public/Set-Context.ps1
@@ -35,8 +35,8 @@ function Set-Context {
     )
 
     begin {
-        $commandName = $MyInvocation.MyCommand.Name
-        Write-Debug "[$commandName] - Start"
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Start"
         Set-ContextVault
         $vaultName = $script:Config.VaultName
         $secretPrefix = $script:Config.SecretPrefix
@@ -73,6 +73,6 @@ function Set-Context {
     }
 
     end {
-        Write-Debug "[$commandName] - End"
+        Write-Debug "[$stackPath] - End"
     }
 }


### PR DESCRIPTION
## Description

This pull request includes changes to improve the debugging output by replacing the use of `$MyInvocation.MyCommand.Name` with a new `Get-PSCallStackPath` function across multiple functions. The new function provides a more detailed call stack path for debugging purposes.

Key changes include:

### Introduction of `Get-PSCallStackPath` function:
* [`src/functions/private/Utilities/PowerShell/Get-PSCallStackPath.ps1`](diffhunk://#diff-c88dcc0009337df33928222cf34aec9da54ec229af8d8aaf8e598047e7b43aaeR1-R49): Added a new function `Get-PSCallStackPath` to generate a string representation of the current call stack.

### Replacement of `$MyInvocation.MyCommand.Name` with `Get-PSCallStackPath`:
* [`src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1`](diffhunk://#diff-56b4d6d08d73e9f82d34b120f3ba7b16b8d60ca37531caebd2c7bec68f9ead42L35-R36): Replaced `$commandName` with `$stackPath` to use the new `Get-PSCallStackPath` function for debugging output. [[1]](diffhunk://#diff-56b4d6d08d73e9f82d34b120f3ba7b16b8d60ca37531caebd2c7bec68f9ead42L35-R36) [[2]](diffhunk://#diff-56b4d6d08d73e9f82d34b120f3ba7b16b8d60ca37531caebd2c7bec68f9ead42L79-R79)
* [`src/functions/private/JsonToObject/ConvertFrom-ContextJson.ps1`](diffhunk://#diff-4b52115c2ce1a1414e44a292fcdff8a38e5e514f5033088475db741661eef168L32-R33): Updated debugging output to use `$stackPath` instead of `$commandName`. [[1]](diffhunk://#diff-4b52115c2ce1a1414e44a292fcdff8a38e5e514f5033088475db741661eef168L32-R33) [[2]](diffhunk://#diff-4b52115c2ce1a1414e44a292fcdff8a38e5e514f5033088475db741661eef168L47-R47)
* [`src/functions/private/ObjectToJson/Convert-ContextObjectToHashtableRecursive.ps1`](diffhunk://#diff-06bd0c6e7bea4b0926769c56c0d8d223b38ef3bd16f9c41c2b43c4a188ad3807L33-R34): Modified to use `$stackPath` for debugging output. [[1]](diffhunk://#diff-06bd0c6e7bea4b0926769c56c0d8d223b38ef3bd16f9c41c2b43c4a188ad3807L33-R34) [[2]](diffhunk://#diff-06bd0c6e7bea4b0926769c56c0d8d223b38ef3bd16f9c41c2b43c4a188ad3807L88-R88)
* [`src/functions/private/ObjectToJson/ConvertTo-ContextJson.ps1`](diffhunk://#diff-30799ea22dccb9e5a3543f914f92e805acc916e59de92fad27bbaf6a4728f97dL39-R40): Updated to use `$stackPath` for debugging output. [[1]](diffhunk://#diff-30799ea22dccb9e5a3543f914f92e805acc916e59de92fad27bbaf6a4728f97dL39-R40) [[2]](diffhunk://#diff-30799ea22dccb9e5a3543f914f92e805acc916e59de92fad27bbaf6a4728f97dL55-R55)
* [`src/functions/private/Set-ContextVault.ps1`](diffhunk://#diff-406313c23db28018a899056d564dcfc471e582e673440c9659a2278316a03673L50-R51): Replaced `$commandName` with `$stackPath` for debugging output. [[1]](diffhunk://#diff-406313c23db28018a899056d564dcfc471e582e673440c9659a2278316a03673L50-R51) [[2]](diffhunk://#diff-406313c23db28018a899056d564dcfc471e582e673440c9659a2278316a03673L99-R99)
* [`src/functions/public/Get-Context.ps1`](diffhunk://#diff-0d7db8bc789bd7b13874d319644d59a93cd442baa4da9f9a20854434d7a2b41aL32-R33): Updated debugging output to use `$stackPath`. [[1]](diffhunk://#diff-0d7db8bc789bd7b13874d319644d59a93cd442baa4da9f9a20854434d7a2b41aL32-R33) [[2]](diffhunk://#diff-0d7db8bc789bd7b13874d319644d59a93cd442baa4da9f9a20854434d7a2b41aL66-R66)
* [`src/functions/public/Get-ContextInfo.ps1`](diffhunk://#diff-332925900b4139bc8c490c79ba22b9717a5547fc676b10239400ab7a0584f132L19-R20): Modified to use `$stackPath` for debugging output. [[1]](diffhunk://#diff-332925900b4139bc8c490c79ba22b9717a5547fc676b10239400ab7a0584f132L19-R20) [[2]](diffhunk://#diff-332925900b4139bc8c490c79ba22b9717a5547fc676b10239400ab7a0584f132L42-R42)
* [`src/functions/public/Remove-Context.ps1`](diffhunk://#diff-bb64b18ab5c85e130b2713ff666adbabfafe59137c69eb19b1375d410872fbabL33-R34): Replaced `$commandName` with `$stackPath` for debugging output. [[1]](diffhunk://#diff-bb64b18ab5c85e130b2713ff666adbabfafe59137c69eb19b1375d410872fbabL33-R34) [[2]](diffhunk://#diff-bb64b18ab5c85e130b2713ff666adbabfafe59137c69eb19b1375d410872fbabL54-R54)
* [`src/functions/public/Rename-Context.ps1`](diffhunk://#diff-6ed8ae834772c9151b6a4143f9962add7e7140dde8118eceab9f6e7103c06b77L31-R32): Updated to use `$stackPath` for debugging output. [[1]](diffhunk://#diff-6ed8ae834772c9151b6a4143f9962add7e7140dde8118eceab9f6e7103c06b77L31-R32) [[2]](diffhunk://#diff-6ed8ae834772c9151b6a4143f9962add7e7140dde8118eceab9f6e7103c06b77L65-R65)
* [`src/functions/public/Set-Context.ps1`](diffhunk://#diff-d12895be2e58b33d275f1d10ec54bd8ee0b555bef81f53d6e39ca1722ea58f44L38-R39): Modified to use `$stackPath` for debugging output. [[1]](diffhunk://#diff-d12895be2e58b33d275f1d10ec54bd8ee0b555bef81f53d6e39ca1722ea58f44L38-R39) [[2]](diffhunk://#diff-d12895be2e58b33d275f1d10ec54bd8ee0b555bef81f53d6e39ca1722ea58f44L76-R76)
## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
