### PR TITLE
🩹 [Patch]: Tweaks on outputs and fix for `Get-ContextInfo`

### DIFF
--- a/src/functions/public/Get-Context.ps1
+++ b/src/functions/public/Get-Context.ps1
@@ -108,7 +108,7 @@ function Get-Context {
 
     begin {
         $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
+        Write-Debug "[$stackPath] - Begin"
     }
 
     process {

--- a/src/functions/public/Get-ContextInfo.ps1
+++ b/src/functions/public/Get-ContextInfo.ps1
@@ -87,34 +87,25 @@
     )
 
     begin {
-        $debug = $DebugPreference -eq 'Continue'
-        if ($debug) {
-            $stackPath = Get-PSCallStackPath
-            Write-Debug "[$stackPath] - Start"
-        }
+        $stackPath = Get-PSCallStackPath
+        Write-Debug "[$stackPath] - Begin"
     }
 
     process {
         $vaults = foreach ($vaultName in $Vault) {
             Get-ContextVault -Name $vaultName -ErrorAction Stop
         }
-        if ($debug) {
-            Write-Debug "[$stackPath] - Found $($vaults.Count) vault(s) matching '$($Vault -join ', ')'."
-        }
+        Write-Debug "[$stackPath] - Found $($vaults.Count) vault(s) matching '$($Vault -join ', ')'."
 
         $files = foreach ($vaultObject in $vaults) {
             Get-ChildItem -Path $vaultObject.Path -Filter *.json -File
         }
-        if ($debug) {
-            Write-Debug "[$stackPath] - Found $($files.Count) context file(s) in vault(s)."
-        }
+        Write-Debug "[$stackPath] - Found $($files.Count) context file(s) in vault(s)."
 
         foreach ($file in $files) {
             $contextInfo = Get-Content -Path $file.FullName | ConvertFrom-Json
-            if ($debug) {
-                Write-Debug "[$stackPath] - Processing file: $($file.FullName)"
-                $contextInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Debug "[$stackPath]   $_" }
-            }
+            Write-Debug "[$stackPath] - Processing file: $($file.FullName)"
+            $contextInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Debug "[$stackPath]   $_" }
             foreach ($IDItem in $ID) {
                 if ($contextInfo.ID -like $IDItem) {
                     $contextInfo

--- a/src/functions/public/Get-ContextInfo.ps1
+++ b/src/functions/public/Get-ContextInfo.ps1
@@ -95,17 +95,17 @@
         $vaults = foreach ($vaultName in $Vault) {
             Get-ContextVault -Name $vaultName -ErrorAction Stop
         }
-        Write-Debug "[$stackPath] - Found $($vaults.Count) vault(s) matching '$($Vault -join ', ')'."
+        Write-Verbose "[$stackPath] - Found $($vaults.Count) vault(s) matching '$($Vault -join ', ')'."
 
         $files = foreach ($vaultObject in $vaults) {
             Get-ChildItem -Path $vaultObject.Path -Filter *.json -File
         }
-        Write-Debug "[$stackPath] - Found $($files.Count) context file(s) in vault(s)."
+        Write-Verbose "[$stackPath] - Found $($files.Count) context file(s) in vault(s)."
 
         foreach ($file in $files) {
             $contextInfo = Get-Content -Path $file.FullName | ConvertFrom-Json
-            Write-Debug "[$stackPath] - Processing file: $($file.FullName)"
-            $contextInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Debug "[$stackPath]   $_" }
+            Write-Verbose "[$stackPath] - Processing file: $($file.FullName)"
+            $contextInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Verbose "[$stackPath]   $_" }
             foreach ($IDItem in $ID) {
                 if ($contextInfo.ID -like $IDItem) {
                     $contextInfo

--- a/src/functions/public/Get-ContextInfo.ps1
+++ b/src/functions/public/Get-ContextInfo.ps1
@@ -115,8 +115,10 @@
                 Write-Debug "[$stackPath] - Processing file: $($file.FullName)"
                 $contextInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Debug "[$stackPath]   $_" }
             }
-            if ($contextInfo.ID -like $ID) {
-                $contextInfo
+            foreach ($IDItem in $ID) {
+                if ($contextInfo.ID -like $IDItem) {
+                    $contextInfo
+                }
             }
         }
     }

--- a/src/functions/public/Remove-Context.ps1
+++ b/src/functions/public/Remove-Context.ps1
@@ -103,9 +103,9 @@
             $contextId = $contextInfo.ID
 
             if ($PSCmdlet.ShouldProcess("Context '$contextId'", 'Remove')) {
-                Write-Debug "[$stackPath] - Removing context [$contextId]"
+                Write-Verbose "[$stackPath] - Removing context [$contextId]"
                 $contextInfo.Path | Remove-Item -Force -ErrorAction Stop
-                Write-Debug "Removed item: $contextId"
+                Write-Verbose "[$stackPath] - Removed item: $contextId"
             }
         }
     }

--- a/src/functions/public/Remove-Context.ps1
+++ b/src/functions/public/Remove-Context.ps1
@@ -105,7 +105,7 @@
             if ($PSCmdlet.ShouldProcess("Context '$contextId'", 'Remove')) {
                 Write-Debug "[$stackPath] - Removing context [$contextId]"
                 $contextInfo.Path | Remove-Item -Force -ErrorAction Stop
-                Write-Output "Removed item: $contextId"
+                Write-Debug "Removed item: $contextId"
             }
         }
     }

--- a/src/functions/public/Rename-Context.ps1
+++ b/src/functions/public/Rename-Context.ps1
@@ -66,7 +66,7 @@
 
     begin {
         $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
+        Write-Debug "[$stackPath] - Begin"
     }
 
     process {

--- a/src/functions/public/Rename-Context.ps1
+++ b/src/functions/public/Rename-Context.ps1
@@ -30,7 +30,7 @@
         Renames the context 'PSModule.GitHub' to 'PSModule.GitHub2' using pipeline input.
 
         .OUTPUTS
-        [System.String]
+        object
 
         .NOTES
         The confirmation message indicating the successful renaming of the context.
@@ -38,7 +38,7 @@
         .LINK
         https://psmodule.io/Context/Functions/Rename-Context/
     #>
-
+    [OutputType([object])]
     [CmdletBinding(SupportsShouldProcess)]
     param (
         # The ID of the context to rename.
@@ -72,15 +72,15 @@
     process {
         $context = Get-Context -ID $ID -Vault $Vault
         if (-not $context) {
-            throw "Context with ID '$ID' not found$(if ($Vault) { " in vault '$Vault'" })."
+            throw "Context with ID '$ID' not found in vault '$Vault'"
         }
 
         $existingContext = Get-Context -ID $NewID -Vault $Vault
         if ($existingContext -and -not $Force) {
-            throw "Context with ID '$NewID' already exists$(if ($Vault) { " in vault '$Vault'" })."
+            throw "Context with ID '$NewID' already exists in vault '$Vault'"
         }
 
-        if ($PSCmdlet.ShouldProcess("Renaming context '$ID' to '$NewID'$(if ($Vault) { " in vault '$Vault'" })")) {
+        if ($PSCmdlet.ShouldProcess("Renaming context '$ID' to '$NewID' in vault '$Vault'")) {
             $context | Set-Context -ID $NewID -Vault $Vault
             Remove-Context -ID $ID -Vault $Vault
         }

--- a/src/functions/public/Set-Context.ps1
+++ b/src/functions/public/Set-Context.ps1
@@ -77,7 +77,7 @@ function Set-Context {
 
     process {
         $vaultObject = Set-ContextVault -Name $Vault
-        $vaultObject | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
+        $vaultObject | Format-List | Out-String -Stream | ForEach-Object { Write-Verbose "[$stackPath]   $_" }
 
         if ($context -is [System.Collections.IDictionary]) {
             $Context = [PSCustomObject]$Context
@@ -92,7 +92,7 @@ function Set-Context {
 
         $contextInfo = Get-ContextInfo -ID $ID -Vault $Vault
         Write-Verbose 'Context info:'
-        $contextInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Verbose $_ }
+        $contextInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Verbose "[$stackPath]   $_" }
         if (-not $contextInfo) {
             Write-Verbose "[$stackPath] - Creating context [$ID] in [$Vault]"
             $guid = [Guid]::NewGuid().Guid
@@ -112,7 +112,7 @@ function Set-Context {
             Context = ConvertTo-SodiumSealedBox -Message $contextJson -PublicKey $keys.PublicKey
         } | ConvertTo-Json -Depth 5
         Write-Verbose 'Content:'
-        $content | ConvertTo-Json -Depth 5 | Out-String -Stream | ForEach-Object { Write-Verbose $_ }
+        $content | ConvertTo-Json -Depth 5 | Out-String -Stream | ForEach-Object { Write-Verbose "[$stackPath]   $_" }
 
         if ($PSCmdlet.ShouldProcess("file: [$contextPath]", 'Set content')) {
             Write-Verbose "[$stackPath] - Setting context [$ID] in vault [$Vault]"

--- a/src/functions/public/Set-Context.ps1
+++ b/src/functions/public/Set-Context.ps1
@@ -77,7 +77,7 @@ function Set-Context {
 
     process {
         $vaultObject = Set-ContextVault -Name $Vault
-        Write-Verbose "$($vaultObject | Format-List | Out-String)"
+        $vaultObject | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
 
         if ($context -is [System.Collections.IDictionary]) {
             $Context = [PSCustomObject]$Context

--- a/src/functions/public/Set-Context.ps1
+++ b/src/functions/public/Set-Context.ps1
@@ -72,7 +72,7 @@ function Set-Context {
 
     begin {
         $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
+        Write-Debug "[$stackPath] - Begin"
     }
 
     process {

--- a/src/functions/public/Vault/Get-ContextVault.ps1
+++ b/src/functions/public/Vault/Get-ContextVault.ps1
@@ -39,7 +39,7 @@
 
     begin {
         $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
+        Write-Debug "[$stackPath] - Begin"
         if (-not (Test-Path -Path $script:Config.RootPath)) {
             return
         }

--- a/src/functions/public/Vault/Remove-ContextVault.ps1
+++ b/src/functions/public/Vault/Remove-ContextVault.ps1
@@ -30,7 +30,7 @@
 
     begin {
         $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
+        Write-Debug "[$stackPath] - Begin"
         $vaults = Get-ContextVault
     }
 

--- a/src/functions/public/Vault/Reset-ContextVault.ps1
+++ b/src/functions/public/Vault/Reset-ContextVault.ps1
@@ -34,7 +34,7 @@
 
     begin {
         $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
+        Write-Debug "[$stackPath] - Begin"
     }
 
     process {

--- a/src/functions/public/Vault/Set-ContextVault.ps1
+++ b/src/functions/public/Vault/Set-ContextVault.ps1
@@ -30,7 +30,7 @@ function Set-ContextVault {
 
     begin {
         $stackPath = Get-PSCallStackPath
-        Write-Debug "[$stackPath] - Start"
+        Write-Debug "[$stackPath] - Begin"
     }
 
     process {

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -188,6 +188,31 @@ Describe 'Context' {
             $results.ID | Should -Contain 'TestID2'
             $results.ID | Should -Not -Contain 'TestID3'
         }
+        It 'Get-Context -ID single - Should not have output leakage (returns only one context)' {
+            $id = 'TestID1'
+            $results = Get-Context -ID $id -Vault 'VaultA'
+            $results | Should -Not -BeNullOrEmpty
+            $results.Count | Should -Be 1
+            $results.ID | Should -Be $id
+        }
+        It 'Get-Context -ID single (nonexistent) - Should not have output leakage (returns nothing)' {
+            $id = 'NonExistentContext'
+            $results = Get-Context -ID $id -Vault 'VaultA'
+            $results | Should -BeNullOrEmpty
+        }
+        It 'Get-Context -ID array with one valid and one invalid - Should not have output leakage (returns only valid)' {
+            $ids = @('TestID1', 'NonExistentContext')
+            $results = Get-Context -ID $ids -Vault 'VaultA'
+            $results | Should -Not -BeNullOrEmpty
+            $results.Count | Should -Be 1
+            $results.ID | Should -Be 'TestID1'
+        }
+        It 'Get-Context -ID with whitespace or null - Should not have output leakage (returns nothing)' {
+            $results = Get-Context -ID '   ' -Vault 'VaultA'
+            $results | Should -BeNullOrEmpty
+            $results = Get-Context -ID $null -Vault 'VaultA'
+            $results | Should -BeNullOrEmpty
+        }
     }
 
     Context 'Remove-Context' {

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -179,7 +179,7 @@ Describe 'Context' {
             { Get-Context -ID $null -Vault 'VaultA' } | Should -Not -Throw
             Get-Context -ID $null -Vault 'VaultA' | Should -BeNullOrEmpty
         }
-        It "Get-Context -ID array - Should return only specified contexts in VaultA" {
+        It 'Get-Context -ID array - Should return only specified contexts in VaultA' {
             $ids = @('TestID1', 'TestID2')
             $results = Get-Context -ID $ids -Vault 'VaultA'
             $results | Should -Not -BeNullOrEmpty

--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -179,6 +179,15 @@ Describe 'Context' {
             { Get-Context -ID $null -Vault 'VaultA' } | Should -Not -Throw
             Get-Context -ID $null -Vault 'VaultA' | Should -BeNullOrEmpty
         }
+        It "Get-Context -ID array - Should return only specified contexts in VaultA" {
+            $ids = @('TestID1', 'TestID2')
+            $results = Get-Context -ID $ids -Vault 'VaultA'
+            $results | Should -Not -BeNullOrEmpty
+            $results.Count | Should -Be 2
+            $results.ID | Should -Contain 'TestID1'
+            $results.ID | Should -Contain 'TestID2'
+            $results.ID | Should -Not -Contain 'TestID3'
+        }
     }
 
     Context 'Remove-Context' {
@@ -303,6 +312,16 @@ Describe 'Context' {
         It 'Should return no results for non-existent context ID in VaultA' {
             $result = Get-ContextInfo -ID 'NonExistentContext' -Vault 'VaultA'
             $result | Should -BeNullOrEmpty
+        }
+
+        It 'Should return only specified contexts for multiple IDs in VaultA' {
+            $ids = @('TestID1', 'TestID2')
+            $results = Get-ContextInfo -ID $ids -Vault 'VaultA'
+            $results | Should -Not -BeNullOrEmpty
+            $results.Count | Should -Be 2
+            $results.ID | Should -Contain 'TestID1'
+            $results.ID | Should -Contain 'TestID2'
+            $results.ID | Should -Not -Contain 'TestID3'
         }
     }
 }


### PR DESCRIPTION
## Description

This pull request introduces several updates to improve code clarity, debugging output, and functionality across multiple PowerShell scripts. Key changes include enhancing debug information, refining error messages, and updating output types for better compatibility.

### Debugging and Logging Enhancements:
* Updated `Get-ContextInfo.ps1` to iterate through multiple IDs (`$ID`) using a `foreach` loop, ensuring compatibility with multiple inputs.
* Changed `Remove-Context.ps1` to use `Write-Debug` instead of `Write-Output` for removed item messages, aligning with debugging practices.
* Modified `Set-Context.ps1` to improve debugging output by processing `Format-List` results as a stream for better readability in logs.

### Error Message Improvements:
* Simplified error messages in `Rename-Context.ps1` by removing conditional text, making them more straightforward and easier to read.

### Output Type Update:
* Updated the output type in `Rename-Context.ps1` from `[System.String]` to `[object]` for broader compatibility and added an explicit `[OutputType([object])]` declaration.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
