### PR TITLE
🪲 [Fix]: Add `-PassThru` parameter to `Set-Context` and `Set-ContextVault` functions for pipeline support

### DIFF
--- a/src/functions/private/Get-ContextVaultKeyPair.ps1
+++ b/src/functions/private/Get-ContextVaultKeyPair.ps1
@@ -32,7 +32,7 @@
     }
 
     process {
-        $vaultObject = Set-ContextVault -Name $Vault
+        $vaultObject = Set-ContextVault -Name $Vault -PassThru
         $shardPath = Join-Path -Path $vaultObject.Path -ChildPath $script:Config.ShardFileName
         $fileShard = Get-Content -Path $shardPath
         $machineShard = [System.Environment]::MachineName

--- a/src/functions/public/Rename-Context.ps1
+++ b/src/functions/public/Rename-Context.ps1
@@ -61,7 +61,11 @@
         # The name of the vault containing the context.
         [Parameter()]
         [ArgumentCompleter({ Complete-ContextVaultName @args })]
-        [string] $Vault
+        [string] $Vault,
+
+        # Pass the context through the pipeline.
+        [Parameter()]
+        [switch] $PassThru
     )
 
     begin {
@@ -81,7 +85,7 @@
         }
 
         if ($PSCmdlet.ShouldProcess("Renaming context '$ID' to '$NewID' in vault '$Vault'")) {
-            $context | Set-Context -ID $NewID -Vault $Vault
+            $context | Set-Context -ID $NewID -Vault $Vault -PassThru:$PassThru
             Remove-Context -ID $ID -Vault $Vault
         }
     }

--- a/src/functions/public/Set-Context.ps1
+++ b/src/functions/public/Set-Context.ps1
@@ -67,7 +67,11 @@ function Set-Context {
         # The name of the vault to store the context in.
         [Parameter(Mandatory)]
         [ArgumentCompleter({ Complete-ContextVaultName @args })]
-        [string] $Vault
+        [string] $Vault,
+
+        # Pass the context through the pipeline.
+        [Parameter()]
+        [switch] $PassThru
     )
 
     begin {
@@ -76,7 +80,7 @@ function Set-Context {
     }
 
     process {
-        $vaultObject = Set-ContextVault -Name $Vault
+        $vaultObject = Set-ContextVault -Name $Vault -PassThru
         $vaultObject | Format-List | Out-String -Stream | ForEach-Object { Write-Verbose "[$stackPath]   $_" }
 
         if ($context -is [System.Collections.IDictionary]) {
@@ -119,7 +123,9 @@ function Set-Context {
             Set-Content -Path $contextPath -Value $content
         }
 
-        Get-Context -ID $ID -Vault $Vault
+        if ($PassThru) {
+            Get-Context -ID $ID -Vault $Vault
+        }
     }
 
     end {

--- a/src/functions/public/Vault/Reset-ContextVault.ps1
+++ b/src/functions/public/Vault/Reset-ContextVault.ps1
@@ -29,7 +29,11 @@
 
         # The vault object to reset.
         [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'As ContextVault')]
-        [ContextVault[]] $InputObject
+        [ContextVault[]] $InputObject,
+
+        # Pass the context through the pipeline.
+        [Parameter()]
+        [switch] $PassThru
     )
 
     begin {
@@ -45,7 +49,7 @@
                         Write-Verbose "Resetting ContextVault [$($vault.Name)] at path [$($vault.Path)]"
                         if ($PSCmdlet.ShouldProcess("ContextVault: [$($vault.Name)]", 'Reset')) {
                             Remove-ContextVault -Name $($vault.Name) -Confirm:$false
-                            Set-ContextVault -Name $($vault.Name)
+                            Set-ContextVault -Name $($vault.Name) -PassThru:$PassThru
                             Write-Verbose "ContextVault [$($vault.Name)] reset successfully."
                         }
                     }

--- a/src/functions/public/Vault/Set-ContextVault.ps1
+++ b/src/functions/public/Vault/Set-ContextVault.ps1
@@ -25,7 +25,11 @@ function Set-ContextVault {
         # The name of the vault to create or update.
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ArgumentCompleter({ Complete-ContextVaultName @args })]
-        [string[]] $Name
+        [string[]] $Name,
+
+        # Pass the context through the pipeline.
+        [Parameter()]
+        [switch] $PassThru
     )
 
     begin {
@@ -52,7 +56,9 @@ function Set-ContextVault {
                 }
             }
 
-            [ContextVault]::new($vaultName, $vaultPath)
+            if ($PassThru) {
+                [ContextVault]::new($vaultName, $vaultPath)
+            }
         }
     }
 

--- a/tests/ContextVaults.Tests.ps1
+++ b/tests/ContextVaults.Tests.ps1
@@ -38,7 +38,7 @@ Describe 'ContextVault' {
         }
 
         It 'Should create a new vault with a single name parameter' {
-            $result = Set-ContextVault -Name 'test-vault1'
+            $result = Set-ContextVault -Name 'test-vault1' -PassThru
             $result | Should -Not -BeNullOrEmpty
             $result | Should -BeOfType [ContextVault]
             $result.Name | Should -Be 'test-vault1'
@@ -46,7 +46,7 @@ Describe 'ContextVault' {
         }
 
         It 'Should create multiple vaults from array parameter' {
-            $results = Set-ContextVault -Name 'test-vault2', 'test-vault3'
+            $results = Set-ContextVault -Name 'test-vault2', 'test-vault3' -PassThru
             $results | Should -HaveCount 2
             $results | ForEach-Object { $_ | Should -BeOfType [ContextVault] }
             $results[0].Name | Should -Be 'test-vault2'
@@ -54,7 +54,7 @@ Describe 'ContextVault' {
         }
 
         It 'Should accept pipeline input for vault creation' {
-            $results = 'test-pipeline1', 'test-pipeline2' | Set-ContextVault
+            $results = 'test-pipeline1', 'test-pipeline2' | Set-ContextVault -PassThru
             $results | Should -HaveCount 2
             $results | ForEach-Object { $_ | Should -BeOfType [ContextVault] }
             $results.Name | Should -Contain 'test-pipeline1'

--- a/tests/ContextVaults.Tests.ps1
+++ b/tests/ContextVaults.Tests.ps1
@@ -208,7 +208,7 @@ Describe 'ContextVault' {
 
         It 'Should support pipeline operations with variables' {
             $testVaults = @('pipeline-var1', 'pipeline-var2')
-            $results = $testVaults | Set-ContextVault
+            $results = $testVaults | Set-ContextVault -PassThru
             $results | Should -HaveCount 2
 
             $getResults = Get-ContextVault -Name $testVaults


### PR DESCRIPTION
## Description

This pull request introduces a new `-PassThru` parameter to the `Set-Context` and `Set-ContextVault` functions, allowing users to pass objects through the pipeline. Corresponding updates have been made to the logic and tests to support this functionality.

### Enhancements to `Set-Context` and `Set-ContextVault` functions:

* **Added `-PassThru` parameter to `Set-Context`:** This optional parameter enables the function to return the context object through the pipeline if specified. (`src/functions/public/Set-Context.ps1`, [[1]](diffhunk://#diff-d12895be2e58b33d275f1d10ec54bd8ee0b555bef81f53d6e39ca1722ea58f44L70-R74) [[2]](diffhunk://#diff-d12895be2e58b33d275f1d10ec54bd8ee0b555bef81f53d6e39ca1722ea58f44R126-R129)
* **Modified `Set-ContextVault` calls within `Set-Context`:** Updated to include the `-PassThru` parameter when invoking `Set-ContextVault`, ensuring consistent behavior. (`src/functions/public/Set-Context.ps1`, [src/functions/public/Set-Context.ps1L79-R83](diffhunk://#diff-d12895be2e58b33d275f1d10ec54bd8ee0b555bef81f53d6e39ca1722ea58f44L79-R83))

### Enhancements to `Set-ContextVault` function:

* **Added `-PassThru` parameter to `Set-ContextVault`:** This optional parameter allows the function to return the created or updated vault object through the pipeline if specified. (`src/functions/public/Vault/Set-ContextVault.ps1`, [[1]](diffhunk://#diff-c61e62f0db098ac07ec081939fe582f191491d491337e1829c95e64ec28e6e8bL28-R32) [[2]](diffhunk://#diff-c61e62f0db098ac07ec081939fe582f191491d491337e1829c95e64ec28e6e8bR59-R63)

### Test updates:

* **Updated tests for `Set-ContextVault`:** Modified test cases to include the `-PassThru` parameter, ensuring the returned objects meet the expected type and content. (`tests/ContextVaults.Tests.ps1`, [tests/ContextVaults.Tests.ps1L41-R57](diffhunk://#diff-0894d6e7273e8c5b7b17bea72b02ec2ce764fbe3478fd1a83e09b3f4ea3dd636L41-R57))

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
