### PR TITLE
🪲 [Fix]: Fix output type of `Get-ContextVault`

### DIFF
--- a/src/functions/public/Vault/Get-ContextVault.ps1
+++ b/src/functions/public/Vault/Get-ContextVault.ps1
@@ -22,12 +22,12 @@
         Gets information about all vaults starting with 'My'.
 
         .OUTPUTS
-        [ContextVault[]]
+        ContextVault
 
         .LINK
         https://psmodule.io/Context/Functions/Vault/Get-ContextVault/
     #>
-    [OutputType([ContextVault[]])]
+    [OutputType([ContextVault])]
     [CmdletBinding()]
     param(
         # The name of the vault to retrieve. Supports wildcards.


### PR DESCRIPTION
## Description

This pull request includes a small change to the `src/functions/public/Vault/Get-ContextVault.ps1` file. The change updates the output type from an array (`[ContextVault[]]`) to a single object (`[ContextVault]`) in both the `.OUTPUTS` section and the `OutputType` attribute.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
