### PR TITLE
🪲 [Fix]: Fix so that the module can manage context with properties with `null` values

### DIFF
--- a/src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1
+++ b/src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1
@@ -66,6 +66,11 @@
                 $value = $Hashtable[$key]
                 Write-Debug "Processing [$key]"
                 Write-Debug "Value: $value"
+                if ($null -eq $value) {
+                    Write-Debug "- as null value"
+                    $result | Add-Member -NotePropertyName $key -NotePropertyValue $null
+                    continue
+                }
                 Write-Debug "Type:  $($value.GetType().Name)"
                 if ($value -is [string] -and $value -like '`[SECURESTRING`]*') {
                     Write-Debug "Converting [$key] as [SecureString]"

--- a/src/functions/private/ObjectToJson/Convert-ContextObjectToHashtableRecursive.ps1
+++ b/src/functions/private/ObjectToJson/Convert-ContextObjectToHashtableRecursive.ps1
@@ -68,6 +68,11 @@
                 $value = $property.Value
                 Write-Debug "Processing [$name]"
                 Write-Debug "Value: $value"
+                if ($null -eq $value) {
+                    Write-Debug '- as null value'
+                    $result[$property.Name] = $null
+                    continue
+                }
                 Write-Debug "Type:  $($value.GetType().Name)"
                 if ($value -is [datetime]) {
                     Write-Debug '- as DateTime'


### PR DESCRIPTION
## Description

This pull request enhances the handling of `null` values in context objects and improves test coverage to ensure proper behavior when working with `null` values. Key changes include updates to recursive conversion functions and the addition of comprehensive test cases.

### Handling of `null` values in conversion functions:
* [`src/functions/private/JsonToObject/Convert-ContextHashtableToObjectRecursive.ps1`](diffhunk://#diff-56b4d6d08d73e9f82d34b120f3ba7b16b8d60ca37531caebd2c7bec68f9ead42R69-R73): Added logic to detect and preserve `null` values when converting hashtables to objects.
* [`src/functions/private/ObjectToJson/Convert-ContextObjectToHashtableRecursive.ps1`](diffhunk://#diff-06bd0c6e7bea4b0926769c56c0d8d223b38ef3bd16f9c41c2b43c4a188ad3807R71-R75): Added logic to detect and preserve `null` values when converting objects to hashtables.

### Enhanced test coverage:
* [`tests/Context.Tests.ps1`](diffhunk://#diff-b7c75aeea4a2f7050d610f7ab27834a431ecf4ace5b964b30cffddb3ef37e921L43-R63): Updated multiple test cases to include validation of `null` properties in context objects, ensuring `null` values are handled correctly during context creation and retrieval. [[1]](diffhunk://#diff-b7c75aeea4a2f7050d610f7ab27834a431ecf4ace5b964b30cffddb3ef37e921L43-R63) [[2]](diffhunk://#diff-b7c75aeea4a2f7050d610f7ab27834a431ecf4ace5b964b30cffddb3ef37e921R132) [[3]](diffhunk://#diff-b7c75aeea4a2f7050d610f7ab27834a431ecf4ace5b964b30cffddb3ef37e921R318-R326)
* [`tests/Context.Tests.ps1`](diffhunk://#diff-b7c75aeea4a2f7050d610f7ab27834a431ecf4ace5b964b30cffddb3ef37e921R163-R208): Added a new test case for complex objects containing `null` values, nested objects, and arrays with mixed values, verifying correct behavior across various scenarios.
* [`tests/Context.Tests.ps1`](diffhunk://#diff-b7c75aeea4a2f7050d610f7ab27834a431ecf4ace5b964b30cffddb3ef37e921R163-R208): Adjusted expected counts for context retrieval tests to account for the newly added test context.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
